### PR TITLE
Add display host for shared DRM fd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCE_FILES drm.c
         gstrtpreceiver.h
         allwinnerv4l2display.cpp
         allwinnerv4l2display.h
+        display_host.cpp
         #
         assembly/memcpymove-v7l.S
         parse_x20_util.h
@@ -51,6 +52,9 @@ pkg_check_modules(LIBDRM REQUIRED libdrm)
 message(STATUS "LIBDRM_LINK_LIBRARIES=${LIBDRM_LINK_LIBRARIES}")
 include_directories(${LIBDRM_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${LIBDRM_LIBRARIES})
+
+add_executable(display_host display_host_main.cpp display_host.cpp drm.c)
+target_link_libraries(display_host pthread m ${LIBDRM_LIBRARIES})
 
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")

--- a/display_host.cpp
+++ b/display_host.cpp
@@ -1,0 +1,156 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "drm.h"
+#ifdef __cplusplus
+}
+#endif
+#include "display_host.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+
+static int send_fd(int sock, int fd) {
+    struct msghdr msg = {0};
+    struct iovec io = { .iov_base = (void*)" ", .iov_len = 1 };
+    char cmsgbuf[CMSG_SPACE(sizeof(fd))];
+    memset(cmsgbuf, 0, sizeof(cmsgbuf));
+    msg.msg_iov = &io;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsgbuf;
+    msg.msg_controllen = sizeof(cmsgbuf);
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN(sizeof(fd));
+    memcpy(CMSG_DATA(cmsg), &fd, sizeof(fd));
+
+    msg.msg_controllen = cmsg->cmsg_len;
+    if (sendmsg(sock, &msg, 0) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int send_drm_fd_to_socket(int fd, const char *socket_path) {
+    struct sockaddr_un addr;
+    int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock < 0) {
+        return -1;
+    }
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+    if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(sock);
+        return -1;
+    }
+    int ret = send_fd(sock, fd);
+    close(sock);
+    return ret;
+}
+
+int receive_fd_from_socket(const char *socket_path) {
+    struct sockaddr_un addr;
+    int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock < 0)
+        return -1;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+    if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(sock);
+        return -1;
+    }
+    struct msghdr msg = {0};
+    char m_buffer[1];
+    struct iovec io = { .iov_base = m_buffer, .iov_len = sizeof(m_buffer) };
+    msg.msg_iov = &io;
+    msg.msg_iovlen = 1;
+
+    char cmsgbuf[CMSG_SPACE(sizeof(int))];
+    msg.msg_control = cmsgbuf;
+    msg.msg_controllen = sizeof(cmsgbuf);
+    if (recvmsg(sock, &msg, 0) < 0) {
+        close(sock);
+        return -1;
+    }
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (!cmsg || cmsg->cmsg_len != CMSG_LEN(sizeof(int))) {
+        close(sock);
+        return -1;
+    }
+    if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
+        close(sock);
+        return -1;
+    }
+    int fd;
+    memcpy(&fd, CMSG_DATA(cmsg), sizeof(fd));
+    close(sock);
+    return fd;
+}
+
+int start_display_host(const char *drm_node, const char *socket_path, int clients, uint16_t mode_width, uint16_t mode_height) {
+    int fd;
+    if (modeset_open(&fd, drm_node) < 0) {
+        return -1;
+    }
+
+    if (mode_width > 0 && mode_height > 0) {
+        struct modeset_output *out = (struct modeset_output *)malloc(sizeof(struct modeset_output));
+        if (!out) {
+            close(fd);
+            return -1;
+        }
+        if (modeset_prepare(fd, out, mode_width, mode_height, 60) == 0) {
+            struct modeset_buf buf = {0};
+            buf.width = mode_width;
+            buf.height = mode_height;
+            if (modeset_create_fb(fd, &buf) == 0) {
+                modeset_perform_modeset(fd, out, out->video_request, &out->video_plane, buf.fb, mode_width, mode_height, 0);
+                modeset_destroy_fb(fd, &buf);
+            }
+            drmModeAtomicFree(out->video_request);
+            modeset_cleanup(fd, out);
+        } else {
+            free(out);
+        }
+    }
+
+    unlink(socket_path);
+    int server = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (server < 0) {
+        close(fd);
+        return -1;
+    }
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+    if (bind(server, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(server);
+        close(fd);
+        return -1;
+    }
+    if (listen(server, clients) < 0) {
+        close(server);
+        close(fd);
+        return -1;
+    }
+    for (int i = 0; i < clients; ++i) {
+        int client = accept(server, NULL, NULL);
+        if (client >= 0) {
+            send_fd(client, fd);
+            close(client);
+        }
+    }
+    close(server);
+    return fd;
+}
+

--- a/display_host.h
+++ b/display_host.h
@@ -1,0 +1,10 @@
+#ifndef DISPLAY_HOST_H
+#define DISPLAY_HOST_H
+
+#include <stdint.h>
+
+int send_drm_fd_to_socket(int fd, const char *socket_path);
+int receive_fd_from_socket(const char *socket_path);
+int start_display_host(const char *drm_node, const char *socket_path, int clients, uint16_t mode_width, uint16_t mode_height);
+
+#endif // DISPLAY_HOST_H

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -1,0 +1,42 @@
+#include "display_host.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    const char *drm_node = "/dev/dri/card0";
+    const char *socket_path = "/tmp/drm-master";
+    int clients = 2;
+    uint16_t width = 0, height = 0;
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "720p") == 0) {
+            width = 1280;
+            height = 720;
+        } else if (strcmp(argv[i], "1080p") == 0) {
+            width = 1920;
+            height = 1080;
+        } else if (strcmp(argv[i], "--socket") == 0 && i + 1 < argc) {
+            socket_path = argv[++i];
+        } else if (strcmp(argv[i], "--drm") == 0 && i + 1 < argc) {
+            drm_node = argv[++i];
+        } else if (strcmp(argv[i], "--clients") == 0 && i + 1 < argc) {
+            clients = atoi(argv[++i]);
+        } else {
+            fprintf(stderr, "Usage: %s [720p|1080p] [--socket path] [--drm node] [--clients n]\n", argv[0]);
+            return 1;
+        }
+    }
+
+    int fd = start_display_host(drm_node, socket_path, clients, width, height);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to start display host\n");
+        return 1;
+    }
+    printf("Display host running. DRM FD %d shared on %s\n", fd, socket_path);
+    while (1) {
+        sleep(60);
+    }
+    return 0;
+}

--- a/main.cpp
+++ b/main.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #include "SchedulingHelper.hpp"
 #include "parse_x20_util.h"
 #include "allwinnerv4l2display.h"
+#include "display_host.h"
 #endif
 
 // This buffer size has no effect on the latency -
@@ -1222,11 +1223,20 @@ int main(int argc, char **argv)
     assert(!ret);
 
     //////////////////////////////////  DRM SETUP
-    ret = modeset_open(&drm_fd, "/dev/dri/card0");
-    if (ret < 0) {
+    const char* fd_socket = getenv("FPVUE_DRM_FD_SOCKET");
+    if (fd_socket) {
+        drm_fd = receive_fd_from_socket(fd_socket);
+        if (drm_fd < 0) {
+            fprintf(stderr, "Failed to receive DRM FD from socket %s\n", fd_socket);
+            return 1;
+        }
+    } else {
+        ret = modeset_open(&drm_fd, "/dev/dri/card0");
+        if (ret < 0) {
             printf("modeset_open() =  %d\n", ret);
+        }
+        assert(drm_fd >= 0);
     }
-    assert(drm_fd >= 0);
     output_list = (struct modeset_output *)malloc(sizeof(struct modeset_output));
     ret = modeset_prepare(drm_fd, output_list, mode_width, mode_height, mode_vrefresh);
     assert(!ret);


### PR DESCRIPTION
## Summary
- allow fpvue to receive a DRM fd via UNIX socket for shared control
- provide display host utilities to send and share DRM master fd
- add build integration for display host helpers
- add CLI tool to start display host with 720p or 1080p modes

## Testing
- `cmake ..`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68bce4af5bdc832fb1d442a392fd77a8