### PR TITLE
Ensure display_host links with sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,14 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
     CMAKE_C_FLAGS
     "${CMAKE_C_FLAGS} -Werror -fsanitize=undefined -fsanitize=address"
   )
+  set(
+    CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=address"
+  )
   target_link_options(${PROJECT_NAME}
+    BEFORE PUBLIC -fsanitize=undefined PUBLIC -fsanitize=address
+  )
+  target_link_options(display_host
     BEFORE PUBLIC -fsanitize=undefined PUBLIC -fsanitize=address
   )
 endif()


### PR DESCRIPTION
## Summary
- Link address and undefined behavior sanitizer runtimes into `display_host`
- Apply sanitizer flags to C++ sources in Debug builds

## Testing
- `./build_debug_cmake.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bce7e713f8832f86a7fa5938cc98cc