### PR TITLE
Launch fpvue as default display_host client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,6 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
 endif()
 
 include(GNUInstallDirs)
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} display_host
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 int main(int argc, char **argv) {
     const char *drm_node = "/dev/dri/card0";
@@ -29,11 +31,22 @@ int main(int argc, char **argv) {
         }
     }
 
+    pid_t pid = fork();
+    if (pid == 0) {
+        sleep(1);
+        setenv("FPVUE_DRM_FD_SOCKET", socket_path, 1);
+        execlp("fpvue", "fpvue", "--aw-display", "--udp-port", "5600", NULL);
+        perror("execlp fpvue");
+        return 1;
+    }
+
     printf("Starting display host with DRM node %s, socket %s, expecting %d clients", drm_node, socket_path, clients);
     if (width > 0 && height > 0) {
         printf(", forcing mode %ux%u", width, height);
     }
     printf("\n");
+    printf("Launched fpvue Allwinner client as PID %d.\n", pid);
+    printf("To run a Qt application against this host, set FPVUE_DRM_FD_SOCKET=%s and launch your app.\n", socket_path);
 
     int fd = start_display_host(drm_node, socket_path, clients, width, height);
     if (fd < 0) {


### PR DESCRIPTION
## Summary
- Start `display_host` by automatically forking a `fpvue` Allwinner client
- Inform users how to connect Qt apps via `FPVUE_DRM_FD_SOCKET`
- Install `display_host` alongside `fpvue`

## Testing
- `cmake -B build`
- `cmake --build build`
- `cmake --install build --prefix /tmp/install`

------
https://chatgpt.com/codex/tasks/task_e_68bcece8b09c832fa8b573e957b19ca1