### PR TITLE
display_host color cycle and Qt5 socket guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,29 @@ Run without any video input and cycle between solid green, red and blue screens:
 fpvue --color-cycle
 ```
 
+### Display host
+
+The `display_host` utility opens the DRM device, shares its file descriptor
+over a UNIX socket and launches `fpvue` in color cycle mode. This is useful for
+testing the display stack or sharing the DRM master with another application.
+
+Run the host:
+
+```
+display_host 720p
+```
+
+To run a Qt5 application against this host, point Qt at the DRM FD socket and
+export the EGLFS platform before launching your app:
+
+```
+export FPVUE_DRM_FD_SOCKET=/tmp/drm-master
+export QT_QPA_PLATFORM=eglfs
+```
+
+The socket path must match the one passed to `display_host` via `--socket`
+ (default: `/tmp/drm-master`).
+
 ### Allwinner A733 experimental mode
 
 The Allwinner path uses the Cedrus V4L2 decoder and presents frames through

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     if (pid == 0) {
         sleep(1);
         setenv("FPVUE_DRM_FD_SOCKET", socket_path, 1);
-        execlp("fpvue", "fpvue", "--aw-display", "--udp-port", "5600", NULL);
+        execlp("fpvue", "fpvue", "--color-cycle", NULL);
         perror("execlp fpvue");
         return 1;
     }
@@ -45,8 +45,8 @@ int main(int argc, char **argv) {
         printf(", forcing mode %ux%u", width, height);
     }
     printf("\n");
-    printf("Launched fpvue Allwinner client as PID %d.\n", pid);
-    printf("To run a Qt application against this host, set FPVUE_DRM_FD_SOCKET=%s and launch your app.\n", socket_path);
+    printf("Launched fpvue color cycle client as PID %d.\n", pid);
+    printf("To run a Qt5 application against this host, set FPVUE_DRM_FD_SOCKET=%s and export QT_QPA_PLATFORM=eglfs before launching your Qt app.\n", socket_path);
 
     int fd = start_display_host(drm_node, socket_path, clients, width, height);
     if (fd < 0) {


### PR DESCRIPTION
## Summary
- run `fpvue` in color cycle mode from `display_host`
- inform Qt5 clients to use `FPVUE_DRM_FD_SOCKET` and `QT_QPA_PLATFORM`
- document Qt5 socket usage in README

## Testing
- `cmake -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68bcef3dc434832f85bfc8312a915aa8