### PR TITLE
Use DRM fd from display host for color cycle

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1029,10 +1029,19 @@ bool color_cycle=false;
 int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh){
     int ret;
     int fd;
-    ret = modeset_open(&fd, "/dev/dri/card0");
-    if (ret < 0) {
-        printf("modeset_open() =  %d\n", ret);
-        return 1;
+    const char* fd_socket = getenv("FPVUE_DRM_FD_SOCKET");
+    if (fd_socket) {
+        fd = receive_fd_from_socket(fd_socket);
+        if (fd < 0) {
+            fprintf(stderr, "Failed to receive DRM FD from socket %s\n", fd_socket);
+            return 1;
+        }
+    } else {
+        ret = modeset_open(&fd, "/dev/dri/card0");
+        if (ret < 0) {
+            printf("modeset_open() =  %d\n", ret);
+            return 1;
+        }
     }
     struct modeset_output *out = (struct modeset_output *)malloc(sizeof(struct modeset_output));
     ret = modeset_prepare(fd, out, mode_width, mode_height, mode_vrefresh);


### PR DESCRIPTION
## Summary
- allow the color cycle test client to connect to the display host via the `FPVUE_DRM_FD_SOCKET` environment variable

## Testing
- `./build_debug_cmake.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bcf5313ee4832fb4baba8b8e11a67b