### PR TITLE
Enable kmscube overlay with display host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ add_compile_options("-Wno-address-of-packed-member")
 
 SET(CMAKE_ASM_FLAGS "${CFLAGS} -x assembler-with-cpp")
 
+include(GNUInstallDirs)
+
 set(SOURCE_FILES drm.c
                                 rtp.c
         main.cpp
@@ -55,6 +57,10 @@ target_link_libraries(${PROJECT_NAME} ${LIBDRM_LIBRARIES})
 
 add_executable(display_host display_host_main.cpp display_host.cpp drm.c)
 target_link_libraries(display_host pthread m ${LIBDRM_LIBRARIES})
+target_compile_definitions(display_host PRIVATE DEFAULT_PRELOAD_PATH="${CMAKE_INSTALL_FULL_LIBDIR}/libdrm_fd_preload.so")
+
+add_library(drm_fd_preload SHARED drm_fd_preload.cpp display_host.cpp)
+target_link_libraries(drm_fd_preload pthread ${LIBDRM_LIBRARIES})
 
 
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
@@ -74,7 +80,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
   )
 endif()
 
-include(GNUInstallDirs)
-install(TARGETS ${PROJECT_NAME} display_host
+install(TARGETS ${PROJECT_NAME} display_host drm_fd_preload
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/README.md
+++ b/README.md
@@ -63,12 +63,20 @@ fpvue --color-cycle
 The `display_host` utility opens the DRM device, shares its file descriptor
 over a UNIX socket and launches `fpvue` in color cycle mode. This is useful for
 testing the display stack or sharing the DRM master with another application.
+It now also starts a `kmscube` instance that renders on a higher z-position
+plane so the color cycle continues to be visible in the background.
 
 Run the host:
 
 ```
 display_host 720p
 ```
+
+`display_host` automatically injects the `libdrm_fd_preload.so` shim in front of
+`kmscube` so it can reuse the DRM master provided over the UNIX socket. The shim
+intercepts calls to open `/dev/dri/card0` and replaces them with the descriptor
+received from the host. To change the default device path, export
+`FPVUE_DRM_DEVICE_PATH` before launching the host.
 
 To run a Qt5 application against this host, point Qt at the DRM FD socket and
 export the EGLFS platform before launching your app:

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -1,10 +1,54 @@
 #include "display_host.h"
+#include <limits.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef DEFAULT_PRELOAD_PATH
+#define DEFAULT_PRELOAD_PATH ""
+#endif
+
+static int build_preload_path(char *buffer, size_t size) {
+    char exe_path[PATH_MAX];
+    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+    if (len < 0)
+        return -1;
+    exe_path[len] = '\0';
+
+    char *slash = strrchr(exe_path, '/');
+    if (!slash)
+        return -1;
+    *slash = '\0';
+
+    const char *filename = "libdrm_fd_preload.so";
+    if (snprintf(buffer, size, "%s/%s", exe_path, filename) < (int)size &&
+        access(buffer, F_OK) == 0) {
+        return 0;
+    }
+
+    char parent[PATH_MAX];
+    strncpy(parent, exe_path, sizeof(parent));
+    parent[sizeof(parent) - 1] = '\0';
+    slash = strrchr(parent, '/');
+    if (slash) {
+        *slash = '\0';
+        if (snprintf(buffer, size, "%s/lib/%s", parent, filename) < (int)size &&
+            access(buffer, F_OK) == 0) {
+            return 0;
+        }
+    }
+
+    if (DEFAULT_PRELOAD_PATH[0] != '\0' &&
+        snprintf(buffer, size, "%s", DEFAULT_PRELOAD_PATH) < (int)size &&
+        access(buffer, F_OK) == 0) {
+        return 0;
+    }
+
+    return -1;
+}
 
 int main(int argc, char **argv) {
     const char *drm_node = "/dev/dri/card0";
@@ -31,12 +75,33 @@ int main(int argc, char **argv) {
         }
     }
 
+    if (clients < 2)
+        clients = 2;
+
     pid_t pid = fork();
     if (pid == 0) {
         sleep(1);
         setenv("FPVUE_DRM_FD_SOCKET", socket_path, 1);
+        setenv("FPVUE_DRM_DEVICE_PATH", drm_node, 1);
+        setenv("FPVUE_COLOR_CYCLE_ZPOS", "0", 1);
         execlp("fpvue", "fpvue", "--color-cycle", NULL);
         perror("execlp fpvue");
+        return 1;
+    }
+
+    pid_t kmscube_pid = fork();
+    if (kmscube_pid == 0) {
+        sleep(2);
+        setenv("FPVUE_DRM_FD_SOCKET", socket_path, 1);
+        setenv("FPVUE_DRM_DEVICE_PATH", drm_node, 1);
+        char preload[PATH_MAX];
+        if (build_preload_path(preload, sizeof(preload)) == 0) {
+            setenv("LD_PRELOAD", preload, 1);
+        } else {
+            fprintf(stderr, "Failed to locate libdrm_fd_preload.so; kmscube may not receive DRM FD\n");
+        }
+        execlp("kmscube", "kmscube", "--atomic", NULL);
+        perror("execlp kmscube");
         return 1;
     }
 
@@ -46,6 +111,7 @@ int main(int argc, char **argv) {
     }
     printf("\n");
     printf("Launched fpvue color cycle client as PID %d.\n", pid);
+    printf("Launched kmscube client as PID %d using overlay plane.\n", kmscube_pid);
     printf("To run a Qt5 application against this host, set FPVUE_DRM_FD_SOCKET=%s and export QT_QPA_PLATFORM=eglfs before launching your Qt app.\n", socket_path);
 
     int fd = start_display_host(drm_node, socket_path, clients, width, height);

--- a/drm_fd_preload.cpp
+++ b/drm_fd_preload.cpp
@@ -1,0 +1,117 @@
+#define _GNU_SOURCE
+#include "display_host.h"
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int (*real_open_fn)(const char *pathname, int flags, ...);
+static int (*real_open64_fn)(const char *pathname, int flags, ...);
+static pthread_mutex_t fd_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int shared_fd = -1;
+
+static const char *target_device_path(void) {
+    const char *path = getenv("FPVUE_DRM_DEVICE_PATH");
+    if (path && path[0] != '\0')
+        return path;
+    return "/dev/dri/card0";
+}
+
+static int ensure_real_open(void) {
+    if (!real_open_fn) {
+        real_open_fn = (int (*)(const char *, int, ...))dlsym(RTLD_NEXT, "open");
+        if (!real_open_fn) {
+            fprintf(stderr, "drm_fd_preload: failed to resolve real open(): %s\n", dlerror());
+            return -1;
+        }
+    }
+    if (!real_open64_fn) {
+        real_open64_fn = (int (*)(const char *, int, ...))dlsym(RTLD_NEXT, "open64");
+        if (!real_open64_fn) {
+            real_open64_fn = real_open_fn;
+        }
+    }
+    return 0;
+}
+
+static int get_shared_fd(void) {
+    const char *socket_path = getenv("FPVUE_DRM_FD_SOCKET");
+    if (!socket_path)
+        return -1;
+
+    if (pthread_mutex_lock(&fd_mutex) != 0)
+        return -1;
+
+    if (shared_fd < 0) {
+        shared_fd = receive_fd_from_socket(socket_path);
+        if (shared_fd < 0) {
+            fprintf(stderr, "drm_fd_preload: failed to receive DRM FD from %s\n", socket_path);
+        }
+    }
+
+    int fd = -1;
+    if (shared_fd >= 0)
+        fd = dup(shared_fd);
+
+    pthread_mutex_unlock(&fd_mutex);
+    return fd;
+}
+
+extern "C" int open(const char *pathname, int flags, ...) {
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = (mode_t)va_arg(args, int);
+        va_end(args);
+    }
+
+    if (pathname && strcmp(pathname, target_device_path()) == 0) {
+        int fd = get_shared_fd();
+        if (fd >= 0)
+            return fd;
+    }
+
+    if (ensure_real_open() < 0)
+        errno = ENOSYS;
+
+    if (!real_open_fn)
+        return -1;
+
+    if (flags & O_CREAT)
+        return real_open_fn(pathname, flags, mode);
+    return real_open_fn(pathname, flags);
+}
+
+extern "C" int open64(const char *pathname, int flags, ...) {
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = (mode_t)va_arg(args, int);
+        va_end(args);
+    }
+
+    if (pathname && strcmp(pathname, target_device_path()) == 0) {
+        int fd = get_shared_fd();
+        if (fd >= 0)
+            return fd;
+    }
+
+    if (ensure_real_open() < 0)
+        errno = ENOSYS;
+
+    if (!real_open64_fn)
+        return -1;
+
+    if (flags & O_CREAT)
+        return real_open64_fn(pathname, flags, mode);
+    return real_open64_fn(pathname, flags);
+}

--- a/main.cpp
+++ b/main.cpp
@@ -1029,6 +1029,12 @@ bool color_cycle=false;
 int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh){
     int ret;
     int fd;
+    int video_zpos = 0;
+    const char* zpos_env = getenv("FPVUE_COLOR_CYCLE_ZPOS");
+    if (zpos_env && *zpos_env) {
+        video_zpos = atoi(zpos_env);
+        printf("Color cycle using zpos %d\n", video_zpos);
+    }
     const char* fd_socket = getenv("FPVUE_DRM_FD_SOCKET");
     if (fd_socket) {
         fd = receive_fd_from_socket(fd_socket);
@@ -1064,7 +1070,7 @@ int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vre
         }
     }
     ret = modeset_perform_modeset(fd, out, out->video_request, &out->video_plane,
-                                  bufs[0].fb, bufs[0].width, bufs[0].height, 0);
+                                  bufs[0].fb, bufs[0].width, bufs[0].height, video_zpos);
     if (ret < 0 && errno == EACCES) {
         drmModePlaneResPtr plane_res = drmModeGetPlaneResources(fd);
         if (plane_res) {
@@ -1093,7 +1099,7 @@ int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vre
                 drmModeAtomicSetCursor(out->video_request, 0);
                 ret = modeset_perform_modeset(fd, out, out->video_request,
                                               &out->video_plane, bufs[0].fb,
-                                              bufs[0].width, bufs[0].height, 0);
+                                              bufs[0].width, bufs[0].height, video_zpos);
             }
             drmModeFreePlaneResources(plane_res);
         }


### PR DESCRIPTION
## Summary
- add a shared library that intercepts DRM device opens and returns the shared master FD
- launch kmscube from display_host with LD_PRELOAD so it renders on an overlay plane above the color cycle
- allow the color cycle test client to choose its z-order layer via FPVUE_COLOR_CYCLE_ZPOS
- ensure display_host locates the installed preload shim and launches kmscube with supported options

## Testing
- cmake -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d056ba8bfc832f8af358cc3368cdfd