### PR TITLE
Pass eglfs platform flag to qopenhd

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ fpvue --color-cycle
 The `display_host` utility opens the DRM device, shares its file descriptor
 over a UNIX socket and launches `fpvue` in color cycle mode. This is useful for
 testing the display stack or sharing the DRM master with another application.
-It now also starts a `kmscube` instance that renders on a higher z-position
-plane so the color cycle continues to be visible in the background.
+It now also starts `qopenhd`, rendering the Qt UI on a higher z-position plane
+so the color cycle continues to be visible in the background. The host passes
+`--platform=eglfs` when launching `qopenhd` so it binds directly to the DRM
+overlay plane.
 
 Run the host:
 
@@ -73,9 +75,9 @@ display_host 720p
 ```
 
 `display_host` automatically injects the `libdrm_fd_preload.so` shim in front of
-`kmscube` so it can reuse the DRM master provided over the UNIX socket. The shim
-intercepts calls to open `/dev/dri/card0` and replaces them with the descriptor
-received from the host. To change the default device path, export
+Qt clients so they can reuse the DRM master provided over the UNIX socket. The
+shim intercepts calls to open `/dev/dri/card0` and replaces them with the
+descriptor received from the host. To change the default device path, export
 `FPVUE_DRM_DEVICE_PATH` before launching the host.
 
 To run a Qt5 application against this host, point Qt at the DRM FD socket and
@@ -87,7 +89,9 @@ export QT_QPA_PLATFORM=eglfs
 ```
 
 The socket path must match the one passed to `display_host` via `--socket`
- (default: `/tmp/drm-master`).
+(default: `/tmp/drm-master`). Qt applications launched by `display_host` set the
+`QT_QPA_PLATFORM` environment variable automatically, but the manual export is
+useful when launching additional clients.
 
 ### Allwinner A733 experimental mode
 

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -50,6 +50,52 @@ static int build_preload_path(char *buffer, size_t size) {
     return -1;
 }
 
+static void configure_shared_drm_environment(const char *socket_path, const char *drm_node) {
+    setenv("FPVUE_DRM_FD_SOCKET", socket_path, 1);
+    setenv("FPVUE_DRM_DEVICE_PATH", drm_node, 1);
+}
+
+static void ensure_preload_in_environment() {
+    char preload[PATH_MAX];
+    if (build_preload_path(preload, sizeof(preload)) != 0) {
+        fprintf(stderr, "Failed to locate libdrm_fd_preload.so; secondary clients may not receive DRM FD\n");
+        return;
+    }
+
+    const char *existing_preload = getenv("LD_PRELOAD");
+    if (existing_preload && existing_preload[0] != '\0') {
+        bool already_present = false;
+        const char *cursor = existing_preload;
+        const size_t preload_len = strlen(preload);
+        while (*cursor) {
+            const char *next = strchr(cursor, ':');
+            size_t token_len = next ? (size_t)(next - cursor) : strlen(cursor);
+            if (token_len == preload_len && strncmp(cursor, preload, token_len) == 0) {
+                already_present = true;
+                break;
+            }
+            if (!next)
+                break;
+            cursor = next + 1;
+        }
+
+        char combined[4096];
+        int written;
+        if (already_present) {
+            written = snprintf(combined, sizeof(combined), "%s", existing_preload);
+        } else {
+            written = snprintf(combined, sizeof(combined), "%s:%s", existing_preload, preload);
+        }
+        if (written >= 0 && written < (int)sizeof(combined)) {
+            setenv("LD_PRELOAD", combined, 1);
+        } else {
+            fprintf(stderr, "Failed to update LD_PRELOAD; buffer too small\n");
+        }
+    } else {
+        setenv("LD_PRELOAD", preload, 1);
+    }
+}
+
 int main(int argc, char **argv) {
     const char *drm_node = "/dev/dri/card0";
     const char *socket_path = "/tmp/drm-master";
@@ -81,58 +127,22 @@ int main(int argc, char **argv) {
     pid_t pid = fork();
     if (pid == 0) {
         sleep(1);
-        setenv("FPVUE_DRM_FD_SOCKET", socket_path, 1);
-        setenv("FPVUE_DRM_DEVICE_PATH", drm_node, 1);
+        configure_shared_drm_environment(socket_path, drm_node);
         setenv("FPVUE_COLOR_CYCLE_ZPOS", "0", 1);
         execlp("fpvue", "fpvue", "--color-cycle", NULL);
         perror("execlp fpvue");
         return 1;
     }
 
-    pid_t kmscube_pid = fork();
-    if (kmscube_pid == 0) {
+    pid_t qopenhd_pid = fork();
+    if (qopenhd_pid == 0) {
         sleep(2);
-        setenv("FPVUE_DRM_FD_SOCKET", socket_path, 1);
-        setenv("FPVUE_DRM_DEVICE_PATH", drm_node, 1);
-        char preload[PATH_MAX];
-        if (build_preload_path(preload, sizeof(preload)) == 0) {
-            const char *existing_preload = getenv("LD_PRELOAD");
-            if (existing_preload && existing_preload[0] != '\0') {
-                bool already_present = false;
-                const char *cursor = existing_preload;
-                const size_t preload_len = strlen(preload);
-                while (*cursor) {
-                    const char *next = strchr(cursor, ':');
-                    size_t token_len = next ? (size_t)(next - cursor) : strlen(cursor);
-                    if (token_len == preload_len && strncmp(cursor, preload, token_len) == 0) {
-                        already_present = true;
-                        break;
-                    }
-                    if (!next)
-                        break;
-                    cursor = next + 1;
-                }
-
-                char combined[4096];
-                int written;
-                if (already_present) {
-                    written = snprintf(combined, sizeof(combined), "%s", existing_preload);
-                } else {
-                    written = snprintf(combined, sizeof(combined), "%s:%s", existing_preload, preload);
-                }
-                if (written >= 0 && written < (int)sizeof(combined)) {
-                    setenv("LD_PRELOAD", combined, 1);
-                } else {
-                    fprintf(stderr, "Failed to update LD_PRELOAD; buffer too small\n");
-                }
-            } else {
-                setenv("LD_PRELOAD", preload, 1);
-            }
-        } else {
-            fprintf(stderr, "Failed to locate libdrm_fd_preload.so; kmscube may not receive DRM FD\n");
-        }
-        execlp("kmscube", "kmscube", "--atomic", NULL);
-        perror("execlp kmscube");
+        configure_shared_drm_environment(socket_path, drm_node);
+        if (!getenv("QT_QPA_PLATFORM"))
+            setenv("QT_QPA_PLATFORM", "eglfs", 1);
+        ensure_preload_in_environment();
+        execlp("qopenhd", "qopenhd", "--platform=eglfs", NULL);
+        perror("execlp qopenhd");
         return 1;
     }
 
@@ -142,8 +152,8 @@ int main(int argc, char **argv) {
     }
     printf("\n");
     printf("Launched fpvue color cycle client as PID %d.\n", pid);
-    printf("Launched kmscube client as PID %d using overlay plane.\n", kmscube_pid);
-    printf("To run a Qt5 application against this host, set FPVUE_DRM_FD_SOCKET=%s and export QT_QPA_PLATFORM=eglfs before launching your Qt app.\n", socket_path);
+    printf("Launched QOpenHD client as PID %d using overlay plane.\n", qopenhd_pid);
+    printf("Qt applications launched by the host automatically share DRM master access via %s.\n", socket_path);
 
     int fd = start_display_host(drm_node, socket_path, clients, width, height);
     if (fd < 0) {


### PR DESCRIPTION
## Summary
- launch qopenhd with `--platform=eglfs` so the Qt UI binds to the shared DRM plane from the host
- document the explicit eglfs platform flag in the display host section of the README

## Testing
- ./build_debug_cmake.sh

------
https://chatgpt.com/codex/tasks/task_e_68d063660324832fa3898c4f86f042b3