### PR TITLE
Handle ASan runtime preloading when launching QOpenHD

### DIFF
--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -1,16 +1,106 @@
 #include "display_host.h"
+#include <ctype.h>
+#include <fstream>
+#include <iterator>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
+#include <vector>
 
 #ifndef DEFAULT_PRELOAD_PATH
 #define DEFAULT_PRELOAD_PATH ""
 #endif
+
+static bool tokenize_preload_contains(const char *preload, const char *library) {
+    if (!preload || !library || library[0] == '\0')
+        return false;
+
+    size_t library_len = strlen(library);
+    const char *cursor = preload;
+    while (cursor && *cursor) {
+        const char *next = strchr(cursor, ':');
+        size_t token_len = next ? static_cast<size_t>(next - cursor) : strlen(cursor);
+        if (token_len == library_len && strncmp(cursor, library, token_len) == 0)
+            return true;
+        if (!next)
+            break;
+        cursor = next + 1;
+    }
+
+    return false;
+}
+
+static bool locate_executable_path(const char *name, char *buffer, size_t size) {
+    if (!name || name[0] == '\0' || !buffer || size == 0)
+        return false;
+
+    if (strchr(name, '/')) {
+        if (access(name, X_OK) == 0) {
+            if (snprintf(buffer, size, "%s", name) < static_cast<int>(size))
+                return true;
+        }
+        return false;
+    }
+
+    const char *path_env = getenv("PATH");
+    if (!path_env)
+        return false;
+
+    char path_copy[4096];
+    strncpy(path_copy, path_env, sizeof(path_copy));
+    path_copy[sizeof(path_copy) - 1] = '\0';
+
+    char *saveptr = nullptr;
+    for (char *token = strtok_r(path_copy, ":", &saveptr); token; token = strtok_r(nullptr, ":", &saveptr)) {
+        if (snprintf(buffer, size, "%s/%s", token, name) >= static_cast<int>(size))
+            continue;
+        if (access(buffer, X_OK) == 0)
+            return true;
+    }
+
+    return false;
+}
+
+static bool extract_linked_library(const char *executable_path, const char *library_prefix, char *buffer, size_t size) {
+    if (!executable_path || !library_prefix || !buffer || size == 0)
+        return false;
+
+    std::ifstream file(executable_path, std::ios::binary);
+    if (!file)
+        return false;
+
+    std::vector<char> data((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    if (data.empty())
+        return false;
+
+    const std::string prefix(library_prefix);
+    for (size_t i = 0; i + prefix.size() <= data.size(); ++i) {
+        if (memcmp(&data[i], prefix.data(), prefix.size()) == 0) {
+            size_t end = i + prefix.size();
+            while (end < data.size()) {
+                char ch = data[end];
+                if (ch == '\0' || (!isalnum(static_cast<unsigned char>(ch)) && ch != '.' && ch != '_' && ch != '-'))
+                    break;
+                ++end;
+            }
+
+            size_t length = end - i;
+            if (length >= size)
+                length = size - 1;
+            memcpy(buffer, &data[i], length);
+            buffer[length] = '\0';
+            return true;
+        }
+    }
+
+    return false;
+}
 
 static int build_preload_path(char *buffer, size_t size) {
     char exe_path[PATH_MAX];
@@ -56,44 +146,42 @@ static void configure_shared_drm_environment(const char *socket_path, const char
     setenv("FPVUE_DRM_DEVICE_PATH", drm_node, 1);
 }
 
-static void ensure_preload_in_environment() {
+static void ensure_preload_in_environment(const char *target_executable) {
     char preload[PATH_MAX];
     if (build_preload_path(preload, sizeof(preload)) != 0) {
         fprintf(stderr, "Failed to locate libdrm_fd_preload.so; secondary clients may not receive DRM FD\n");
         return;
     }
 
-    const char *existing_preload = getenv("LD_PRELOAD");
-    if (existing_preload && existing_preload[0] != '\0') {
-        bool already_present = false;
-        const char *cursor = existing_preload;
-        const size_t preload_len = strlen(preload);
-        while (*cursor) {
-            const char *next = strchr(cursor, ':');
-            size_t token_len = next ? (size_t)(next - cursor) : strlen(cursor);
-            if (token_len == preload_len && strncmp(cursor, preload, token_len) == 0) {
-                already_present = true;
-                break;
+    char asan_library[256];
+    bool add_asan_preload = false;
+    if (target_executable && target_executable[0] != '\0') {
+        char executable_path[PATH_MAX];
+        if (locate_executable_path(target_executable, executable_path, sizeof(executable_path))) {
+            if (extract_linked_library(executable_path, "libasan.so", asan_library, sizeof(asan_library))) {
+                add_asan_preload = true;
             }
-            if (!next)
-                break;
-            cursor = next + 1;
         }
+    }
 
-        char combined[4096];
-        int written;
-        if (already_present) {
-            written = snprintf(combined, sizeof(combined), "%s", existing_preload);
-        } else {
-            written = snprintf(combined, sizeof(combined), "%s:%s", existing_preload, preload);
-        }
-        if (written >= 0 && written < (int)sizeof(combined)) {
-            setenv("LD_PRELOAD", combined, 1);
-        } else {
-            fprintf(stderr, "Failed to update LD_PRELOAD; buffer too small\n");
-        }
-    } else {
-        setenv("LD_PRELOAD", preload, 1);
+    const char *existing_preload = getenv("LD_PRELOAD");
+    std::string combined_preload = existing_preload ? existing_preload : "";
+
+    if (add_asan_preload && !tokenize_preload_contains(combined_preload.c_str(), asan_library)) {
+        if (!combined_preload.empty())
+            combined_preload = std::string(asan_library) + ":" + combined_preload;
+        else
+            combined_preload = asan_library;
+    }
+
+    if (!tokenize_preload_contains(combined_preload.c_str(), preload)) {
+        if (!combined_preload.empty())
+            combined_preload += ":";
+        combined_preload += preload;
+    }
+
+    if (!combined_preload.empty()) {
+        setenv("LD_PRELOAD", combined_preload.c_str(), 1);
     }
 }
 
@@ -207,7 +295,7 @@ int main(int argc, char **argv) {
         }
 
         setenv("QT_LOGGING_TO_CONSOLE", "1", 1);
-        ensure_preload_in_environment();
+        ensure_preload_in_environment("qopenhd");
         execlp("qopenhd", "qopenhd", "--platform=eglfs", NULL);
         perror("execlp qopenhd");
         return 1;


### PR DESCRIPTION
## Summary
- detect when the QOpenHD binary depends on AddressSanitizer and ensure its runtime stays at the front of `LD_PRELOAD`
- append the DRM FD sharing shim to any existing preload entries without clobbering sanitizer requirements

## Testing
- cmake --build build_debug

------
https://chatgpt.com/codex/tasks/task_e_68d0705fd9ec832fb55bc3d78d621237