### PR TITLE
Fix DRM plane selection and memory leak

### DIFF
--- a/allwinnerv4l2display.cpp
+++ b/allwinnerv4l2display.cpp
@@ -88,7 +88,7 @@ bool AllwinnerV4L2Display::setup_network() {
 
 bool AllwinnerV4L2Display::setup_drm() {
   if (modeset_open(&m_drm_fd, "/dev/dri/card0") < 0) return false;
-  if (modeset_prepare(m_drm_fd, &m_output, kVideoWidth, kVideoHeight, 60) <
+  if (modeset_prepare(m_drm_fd, &m_output, kVideoWidth, kVideoHeight, 60, DRM_FORMAT_NV12) <
       0)
     return false;
   return true;

--- a/display_host.cpp
+++ b/display_host.cpp
@@ -111,7 +111,7 @@ int start_display_host(const char *drm_node, const char *socket_path, int client
             close(fd);
             return -1;
         }
-        if (modeset_prepare(fd, out, mode_width, mode_height, 60) == 0) {
+        if (modeset_prepare(fd, out, mode_width, mode_height, 60, DRM_FORMAT_ARGB8888) == 0) {
             struct modeset_buf buf = {0};
             buf.width = mode_width;
             buf.height = mode_height;

--- a/drm.c
+++ b/drm.c
@@ -200,8 +200,10 @@ int modeset_find_crtc(int fd, drmModeRes *res, drmModeConnector *conn, struct mo
 	return -ENOENT;
 }
 
-const char* drm_fourcc_to_string(uint32_t fourcc) {
+char* drm_fourcc_to_string(uint32_t fourcc) {
     char* result = malloc(5);
+    if (!result)
+            return NULL;
     result[0] = (char)((fourcc >> 0) & 0xFF);
     result[1] = (char)((fourcc >> 8) & 0xFF);
     result[2] = (char)((fourcc >> 16) & 0xFF);
@@ -394,7 +396,7 @@ void modeset_output_destroy(int fd, struct modeset_output *out)
         free(out);
 }
 
-struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh)
+struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format)
 {
 	int ret;
 	struct modeset_output *out;
@@ -446,12 +448,18 @@ struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeCon
 		goto out_blob;
 	}
 
-	ret = modeset_find_plane(fd, out, &out->video_plane, DRM_FORMAT_NV12);
-	if (ret) {
-		fprintf(stderr, "no valid video plane with format NV12 for crtc %u\n", out->crtc.id);
-		goto out_blob;
-	}
-	fprintf(stdout, "Using plane %d (NV12) for Video\n",  out->video_plane.id);
+        ret = modeset_find_plane(fd, out, &out->video_plane, plane_format);
+        if (ret) {
+                char *format_str = drm_fourcc_to_string(plane_format);
+                fprintf(stderr, "no valid video plane with format %s for crtc %u\n",
+                        format_str ? format_str : "????", out->crtc.id);
+                free(format_str);
+                goto out_blob;
+        }
+        char *format_str = drm_fourcc_to_string(plane_format);
+        fprintf(stdout, "Using plane %d (%s) for Video\n",  out->video_plane.id,
+                format_str ? format_str : "????");
+        free(format_str);
 
         ret = modeset_setup_objects(fd, out);
         if (ret) {
@@ -481,42 +489,45 @@ out_error:
 }
 
 
-int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh)
+int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format)
 {
-	drmModeRes *res;
-	drmModeConnector *conn;
-	unsigned int i;
-	struct modeset_output *out;
+        drmModeRes *res;
+        drmModeConnector *conn;
+        unsigned int i;
+        struct modeset_output *out;
+        bool found_output = false;
 
-	res = drmModeGetResources(fd);
-	if (!res) {
-		fprintf(stderr, "cannot retrieve DRM resources (%d): %m\n",
-			errno);
-		return -errno;
-	}
+        res = drmModeGetResources(fd);
+        if (!res) {
+                fprintf(stderr, "cannot retrieve DRM resources (%d): %m\n",
+                        errno);
+                return -errno;
+        }
 
-	for (i = 0; i < res->count_connectors; ++i) {
-		conn = drmModeGetConnector(fd, res->connectors[i]);
-		if (!conn) {
-			fprintf(stderr, "cannot retrieve DRM connector %u:%u (%d): %m\n",
-				i, res->connectors[i], errno);
-			continue;
-		}
+        for (i = 0; i < res->count_connectors; ++i) {
+                conn = drmModeGetConnector(fd, res->connectors[i]);
+                if (!conn) {
+                        fprintf(stderr, "cannot retrieve DRM connector %u:%u (%d): %m\n",
+                                i, res->connectors[i], errno);
+                        continue;
+                }
 
-		out = modeset_output_create(fd, res, conn, mode_width, mode_height, mode_vrefresh);
-		drmModeFreeConnector(conn);
-		if (!out)
-			continue;
+                out = modeset_output_create(fd, res, conn, mode_width, mode_height, mode_vrefresh, plane_format);
+                drmModeFreeConnector(conn);
+                if (!out)
+                        continue;
 
-		*output_list = *out;
-	}
-	if (!output_list) {
-		fprintf(stderr, "couldn't create any outputs\n");
-		return -1;
-	}
+                *output_list = *out;
+                found_output = true;
+                free(out);
+        }
+        drmModeFreeResources(res);
+        if (!found_output) {
+                fprintf(stderr, "couldn't create any outputs\n");
+                return -1;
+        }
 
-	drmModeFreeResources(res);
-	return 0;
+        return 0;
 }
 
 int modeset_perform_modeset(int fd, struct modeset_output *out, drmModeAtomicReq * req, struct drm_object *plane, int fb_id, int width, int height, int zpos)

--- a/drm.h
+++ b/drm.h
@@ -83,7 +83,7 @@ int set_drm_object_property(drmModeAtomicReq *req, struct drm_object *obj,  cons
 
 int modeset_find_crtc(int fd, drmModeRes *res, drmModeConnector *conn, struct modeset_output *out);
 
-const char* drm_fourcc_to_string(uint32_t fourcc);
+char* drm_fourcc_to_string(uint32_t fourcc);
 
 int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *plane_out, uint32_t plane_format);
 
@@ -101,9 +101,9 @@ int modeset_setup_framebuffers(int fd, drmModeConnector *conn, struct modeset_ou
 
 void modeset_output_destroy(int fd, struct modeset_output *out);
 
-struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh);
+struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format);
 
-int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh);
+int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format);
 
 int modeset_perform_modeset(int fd, struct modeset_output *out, drmModeAtomicReq * req, struct drm_object *plane, int fb_id, int width, int height, int zpos);
 

--- a/main.cpp
+++ b/main.cpp
@@ -1050,7 +1050,7 @@ int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vre
         }
     }
     struct modeset_output *out = (struct modeset_output *)malloc(sizeof(struct modeset_output));
-    ret = modeset_prepare(fd, out, mode_width, mode_height, mode_vrefresh);
+    ret = modeset_prepare(fd, out, mode_width, mode_height, mode_vrefresh, DRM_FORMAT_ARGB8888);
     if (ret) {
         close(fd);
         free(out);
@@ -1071,7 +1071,7 @@ int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vre
     }
     ret = modeset_perform_modeset(fd, out, out->video_request, &out->video_plane,
                                   bufs[0].fb, bufs[0].width, bufs[0].height, video_zpos);
-    if (ret < 0 && errno == EACCES) {
+    if (ret == -EACCES || ret == -EPERM) {
         drmModePlaneResPtr plane_res = drmModeGetPlaneResources(fd);
         if (plane_res) {
             for (uint32_t p = 0; p < plane_res->count_planes && ret < 0; ++p) {
@@ -1084,7 +1084,7 @@ int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vre
                 bool usable = false;
                 if (plane->possible_crtcs & (1 << out->crtc_index)) {
                     for (int j = 0; j < plane->count_formats; j++) {
-                        if (plane->formats[j] == DRM_FORMAT_NV12) {
+                        if (plane->formats[j] == DRM_FORMAT_ARGB8888) {
                             usable = true;
                             break;
                         }
@@ -1253,7 +1253,7 @@ int main(int argc, char **argv)
         assert(drm_fd >= 0);
     }
     output_list = (struct modeset_output *)malloc(sizeof(struct modeset_output));
-    ret = modeset_prepare(drm_fd, output_list, mode_width, mode_height, mode_vrefresh);
+    ret = modeset_prepare(drm_fd, output_list, mode_width, mode_height, mode_vrefresh, DRM_FORMAT_NV12);
     assert(!ret);
 
     ////////////////////////////////// MPI SETUP


### PR DESCRIPTION
## Summary
- allow callers to request a specific DRM plane format when preparing a modeset and log the selected plane format
- resolve the temporary modeset_output leak in modeset_prepare and handle FOURCC string allocation failures
- request ARGB planes for the color-cycle/display host paths and NV12 planes for the video pipelines

## Testing
- ./build_debug_cmake.sh

------
https://chatgpt.com/codex/tasks/task_e_68d07e35b16c832f9cb4d8de0c068ba3