### PR TITLE
Ensure fpvue uses primary plane and hide it from QOpenHD

### DIFF
--- a/allwinnerv4l2display.cpp
+++ b/allwinnerv4l2display.cpp
@@ -88,8 +88,8 @@ bool AllwinnerV4L2Display::setup_network() {
 
 bool AllwinnerV4L2Display::setup_drm() {
   if (modeset_open(&m_drm_fd, "/dev/dri/card0") < 0) return false;
-  if (modeset_prepare(m_drm_fd, &m_output, kVideoWidth, kVideoHeight, 60, DRM_FORMAT_NV12) <
-      0)
+  if (modeset_prepare(m_drm_fd, &m_output, kVideoWidth, kVideoHeight, 60, DRM_FORMAT_NV12,
+                      MODESET_PLANE_TYPE_PRIMARY) < 0)
     return false;
   return true;
 }

--- a/display_host.cpp
+++ b/display_host.cpp
@@ -111,7 +111,8 @@ int start_display_host(const char *drm_node, const char *socket_path, int client
             close(fd);
             return -1;
         }
-        if (modeset_prepare(fd, out, mode_width, mode_height, 60, DRM_FORMAT_ARGB8888) == 0) {
+        if (modeset_prepare(fd, out, mode_width, mode_height, 60, DRM_FORMAT_ARGB8888,
+                            MODESET_PLANE_TYPE_PRIMARY) == 0) {
             struct modeset_buf buf = {0};
             buf.width = mode_width;
             buf.height = mode_height;

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -13,9 +13,116 @@
 #include <unistd.h>
 #include <vector>
 
+extern "C" {
+#include "drm.h"
+}
+#include <xf86drmMode.h>
+
 #ifndef DEFAULT_PRELOAD_PATH
 #define DEFAULT_PRELOAD_PATH ""
 #endif
+
+struct PlaneAssignment {
+    uint32_t primary_plane_id = 0;
+    uint32_t overlay_plane_id = 0;
+    uint32_t connector_id = 0;
+    std::string connector_name;
+};
+
+static const char *connector_type_to_string(uint32_t type) {
+    switch (type) {
+    case DRM_MODE_CONNECTOR_VGA:
+        return "VGA";
+    case DRM_MODE_CONNECTOR_DVII:
+        return "DVI-I";
+    case DRM_MODE_CONNECTOR_DVID:
+        return "DVI-D";
+    case DRM_MODE_CONNECTOR_DVIA:
+        return "DVI-A";
+    case DRM_MODE_CONNECTOR_Composite:
+        return "Composite";
+    case DRM_MODE_CONNECTOR_SVIDEO:
+        return "SVIDEO";
+    case DRM_MODE_CONNECTOR_LVDS:
+        return "LVDS";
+    case DRM_MODE_CONNECTOR_Component:
+        return "Component";
+    case DRM_MODE_CONNECTOR_9PinDIN:
+        return "DIN";
+    case DRM_MODE_CONNECTOR_DisplayPort:
+        return "DP";
+    case DRM_MODE_CONNECTOR_HDMIA:
+        return "HDMI-A";
+    case DRM_MODE_CONNECTOR_HDMIB:
+        return "HDMI-B";
+    case DRM_MODE_CONNECTOR_TV:
+        return "TV";
+    case DRM_MODE_CONNECTOR_eDP:
+        return "eDP";
+    case DRM_MODE_CONNECTOR_VIRTUAL:
+        return "Virtual";
+    case DRM_MODE_CONNECTOR_DSI:
+        return "DSI";
+    case DRM_MODE_CONNECTOR_DPI:
+        return "DPI";
+#ifdef DRM_MODE_CONNECTOR_WRITEBACK
+    case DRM_MODE_CONNECTOR_WRITEBACK:
+        return "Writeback";
+#endif
+#ifdef DRM_MODE_CONNECTOR_SPI
+    case DRM_MODE_CONNECTOR_SPI:
+        return "SPI";
+#endif
+#ifdef DRM_MODE_CONNECTOR_USB
+    case DRM_MODE_CONNECTOR_USB:
+        return "USB";
+#endif
+    default:
+        return "Unknown";
+    }
+}
+
+static std::string build_connector_name(uint32_t type, uint32_t type_id) {
+    char buffer[64];
+    snprintf(buffer, sizeof(buffer), "%s-%u", connector_type_to_string(type), type_id);
+    return std::string(buffer);
+}
+
+static bool determine_plane_assignment(const char *drm_node, PlaneAssignment &assignment) {
+    assignment = PlaneAssignment{};
+    int fd;
+    if (modeset_open(&fd, drm_node) < 0) {
+        fprintf(stderr, "Failed to open DRM node %s when determining plane assignment.\n", drm_node);
+        return false;
+    }
+
+    struct modeset_output out{};
+    if (modeset_prepare(fd, &out, 0, 0, 0, DRM_FORMAT_ARGB8888, MODESET_PLANE_TYPE_PRIMARY) != 0) {
+        fprintf(stderr, "Unable to locate a primary plane on %s.\n", drm_node);
+        close(fd);
+        return false;
+    }
+
+    assignment.primary_plane_id = out.video_plane.id;
+    assignment.connector_id = out.connector.id;
+
+    struct drm_object overlay_plane{};
+    if (modeset_find_plane(fd, &out, &overlay_plane, DRM_FORMAT_ARGB8888, MODESET_PLANE_TYPE_OVERLAY) == 0) {
+        assignment.overlay_plane_id = overlay_plane.id;
+    } else {
+        fprintf(stderr, "Warning: no overlay plane supporting ARGB8888 detected on %s.\n", drm_node);
+    }
+
+    drmModeConnectorPtr connector = drmModeGetConnector(fd, assignment.connector_id);
+    if (connector) {
+        assignment.connector_name = build_connector_name(connector->connector_type, connector->connector_type_id);
+        drmModeFreeConnector(connector);
+    }
+
+    modeset_cleanup(fd, &out);
+    close(fd);
+    return assignment.primary_plane_id != 0;
+}
 
 static bool tokenize_preload_contains(const char *preload, const char *library) {
     if (!preload || !library || library[0] == '\0')
@@ -302,6 +409,18 @@ int main(int argc, char **argv) {
     if (clients < 2)
         clients = 2;
 
+    PlaneAssignment plane_assignment;
+    bool have_plane_assignment = determine_plane_assignment(drm_node, plane_assignment);
+    if (have_plane_assignment) {
+        const char *connector = plane_assignment.connector_name.empty() ? "connector" : plane_assignment.connector_name.c_str();
+        printf("Detected primary plane %u and overlay plane %u on %s.\n",
+               plane_assignment.primary_plane_id,
+               plane_assignment.overlay_plane_id,
+               connector);
+    } else {
+        fprintf(stderr, "Warning: failed to determine plane assignment; clients may contend for the same plane.\n");
+    }
+
     pid_t pid = fork();
     if (pid == 0) {
         sleep(1);
@@ -330,6 +449,16 @@ int main(int argc, char **argv) {
     if (qopenhd_pid == 0) {
         sleep(2);
         configure_shared_drm_environment(socket_path, drm_node);
+        if (have_plane_assignment && plane_assignment.primary_plane_id != 0) {
+            char reserved_planes[32];
+            snprintf(reserved_planes, sizeof(reserved_planes), "%u", plane_assignment.primary_plane_id);
+            setenv("FPVUE_RESERVED_PLANE_IDS", reserved_planes, 1);
+            if (plane_assignment.overlay_plane_id != 0) {
+                char overlay_plane[32];
+                snprintf(overlay_plane, sizeof(overlay_plane), "%u", plane_assignment.overlay_plane_id);
+                setenv("FPVUE_OVERLAY_PLANE_ID", overlay_plane, 1);
+            }
+        }
         const char *current_platform = getenv("QT_QPA_PLATFORM");
         if (!current_platform || strcmp(current_platform, "eglfs") != 0)
             setenv("QT_QPA_PLATFORM", "eglfs", 1);
@@ -400,7 +529,17 @@ int main(int argc, char **argv) {
     }
     printf("\n");
     printf("Launched fpvue color cycle client as PID %d.\n", pid);
-    printf("Launched QOpenHD client as PID %d using overlay plane.\n", qopenhd_pid);
+    if (have_plane_assignment) {
+        printf("Reserved primary plane %u for fpvue.\n", plane_assignment.primary_plane_id);
+        if (plane_assignment.overlay_plane_id != 0) {
+            printf("Launched QOpenHD client as PID %d with overlay plane %u available.\n", qopenhd_pid,
+                   plane_assignment.overlay_plane_id);
+        } else {
+            printf("Launched QOpenHD client as PID %d with overlay plane discovery unavailable.\n", qopenhd_pid);
+        }
+    } else {
+        printf("Launched QOpenHD client as PID %d using overlay plane.\n", qopenhd_pid);
+    }
     std::thread([qopenhd_pid]() {
         int status = 0;
         pid_t result = waitpid(qopenhd_pid, &status, 0);

--- a/drm.c
+++ b/drm.c
@@ -242,7 +242,7 @@ char* drm_fourcc_to_string(uint32_t fourcc) {
     return result;
 }
 
-int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *plane_out, uint32_t plane_format)
+int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *plane_out, uint32_t plane_format, enum modeset_plane_type plane_type)
 {
         drmModePlaneResPtr plane_res;
         bool found_plane = false;
@@ -256,7 +256,12 @@ int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *pl
                 return -ENOENT;
         }
 
-        bool prefer_primary = (plane_format == DRM_FORMAT_ARGB8888);
+        bool prefer_primary = (plane_type == MODESET_PLANE_TYPE_PRIMARY) ||
+                              (plane_type == MODESET_PLANE_TYPE_ANY && plane_format == DRM_FORMAT_ARGB8888);
+        bool prefer_overlay = (plane_type == MODESET_PLANE_TYPE_OVERLAY) ||
+                              (plane_type == MODESET_PLANE_TYPE_ANY && plane_format != DRM_FORMAT_ARGB8888);
+        bool require_primary = (plane_type == MODESET_PLANE_TYPE_PRIMARY);
+        bool require_overlay = (plane_type == MODESET_PLANE_TYPE_OVERLAY);
         for (i = 0; i < plane_res->count_planes; i++) {
                 int plane_id = plane_res->planes[i];
                 bool matches = false;
@@ -279,15 +284,25 @@ int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *pl
                 }
 
                 if (matches) {
-                        uint64_t plane_type;
-                        if (get_plane_type_value(fd, plane_id, &plane_type)) {
-                                if (plane_type == DRM_PLANE_TYPE_PRIMARY) {
-                                        priority = prefer_primary ? 0 : 1;
-                                } else if (plane_type == DRM_PLANE_TYPE_OVERLAY) {
-                                        priority = prefer_primary ? 1 : 0;
+                        uint64_t plane_type_value;
+                        if (get_plane_type_value(fd, plane_id, &plane_type_value)) {
+                                if (plane_type_value == DRM_PLANE_TYPE_PRIMARY) {
+                                        if (require_overlay) {
+                                                matches = false;
+                                        } else {
+                                                priority = prefer_primary ? 0 : 1;
+                                        }
+                                } else if (plane_type_value == DRM_PLANE_TYPE_OVERLAY) {
+                                        if (require_primary) {
+                                                matches = false;
+                                        } else {
+                                                priority = prefer_overlay ? 0 : 1;
+                                        }
                                 } else {
                                         matches = false;
                                 }
+                        } else {
+                                matches = false;
                         }
                 }
 
@@ -450,7 +465,7 @@ void modeset_output_destroy(int fd, struct modeset_output *out)
         free(out);
 }
 
-struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format)
+struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format, enum modeset_plane_type plane_type)
 {
 	int ret;
 	struct modeset_output *out;
@@ -502,11 +517,16 @@ struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeCon
 		goto out_blob;
 	}
 
-        ret = modeset_find_plane(fd, out, &out->video_plane, plane_format);
+        ret = modeset_find_plane(fd, out, &out->video_plane, plane_format, plane_type);
         if (ret) {
                 char *format_str = drm_fourcc_to_string(plane_format);
-                fprintf(stderr, "no valid video plane with format %s for crtc %u\n",
-                        format_str ? format_str : "????", out->crtc.id);
+                const char *type_requirement = "any";
+                if (plane_type == MODESET_PLANE_TYPE_PRIMARY)
+                        type_requirement = "primary";
+                else if (plane_type == MODESET_PLANE_TYPE_OVERLAY)
+                        type_requirement = "overlay";
+                fprintf(stderr, "no valid %s video plane with format %s for crtc %u\n",
+                        type_requirement, format_str ? format_str : "????", out->crtc.id);
                 free(format_str);
                 goto out_blob;
         }
@@ -553,7 +573,7 @@ out_error:
 }
 
 
-int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format)
+int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format, enum modeset_plane_type plane_type)
 {
         drmModeRes *res;
         drmModeConnector *conn;
@@ -576,7 +596,7 @@ int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_wi
                         continue;
                 }
 
-                out = modeset_output_create(fd, res, conn, mode_width, mode_height, mode_vrefresh, plane_format);
+                out = modeset_output_create(fd, res, conn, mode_width, mode_height, mode_vrefresh, plane_format, plane_type);
                 drmModeFreeConnector(conn);
                 if (!out)
                         continue;

--- a/drm.h
+++ b/drm.h
@@ -44,6 +44,12 @@ struct modeset_buf {
 	uint32_t fb;
 };
 
+enum modeset_plane_type {
+        MODESET_PLANE_TYPE_ANY = 0,
+        MODESET_PLANE_TYPE_PRIMARY,
+        MODESET_PLANE_TYPE_OVERLAY,
+};
+
 struct modeset_output {
 	struct drm_object connector;
 	struct drm_object crtc;
@@ -85,7 +91,7 @@ int modeset_find_crtc(int fd, drmModeRes *res, drmModeConnector *conn, struct mo
 
 char* drm_fourcc_to_string(uint32_t fourcc);
 
-int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *plane_out, uint32_t plane_format);
+int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *plane_out, uint32_t plane_format, enum modeset_plane_type plane_type);
 
 void modeset_drm_object_fini(struct drm_object *obj);
 
@@ -101,9 +107,9 @@ int modeset_setup_framebuffers(int fd, drmModeConnector *conn, struct modeset_ou
 
 void modeset_output_destroy(int fd, struct modeset_output *out);
 
-struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format);
+struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeConnector *conn, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format, enum modeset_plane_type plane_type);
 
-int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format);
+int modeset_prepare(int fd, struct modeset_output *output_list, uint16_t mode_width, uint16_t mode_height, uint32_t mode_vrefresh, uint32_t plane_format, enum modeset_plane_type plane_type);
 
 int modeset_perform_modeset(int fd, struct modeset_output *out, drmModeAtomicReq * req, struct drm_object *plane, int fb_id, int width, int height, int zpos);
 

--- a/drm_fd_preload.cpp
+++ b/drm_fd_preload.cpp
@@ -11,11 +11,21 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <algorithm>
+#include <stdint.h>
+#include <vector>
+#include <xf86drmMode.h>
 
 static int (*real_open_fn)(const char *pathname, int flags, ...);
 static int (*real_open64_fn)(const char *pathname, int flags, ...);
+static drmModePlaneResPtr (*real_drmModeGetPlaneResources_fn)(int fd);
+static drmModePlanePtr (*real_drmModeGetPlane_fn)(int fd, uint32_t plane_id);
 static pthread_mutex_t fd_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t reserved_plane_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int shared_fd = -1;
+static bool reserved_plane_ids_initialized = false;
+static bool reserved_plane_ids_logged = false;
+static std::vector<uint32_t> reserved_plane_ids;
 
 static bool should_intercept_path(const char *pathname) {
     if (!pathname)
@@ -72,6 +82,82 @@ static int get_shared_fd(void) {
     return fd;
 }
 
+static void parse_reserved_plane_ids_locked(void) {
+    const char *env = getenv("FPVUE_RESERVED_PLANE_IDS");
+    reserved_plane_ids.clear();
+    if (!env)
+        return;
+
+    const char *cursor = env;
+    while (*cursor) {
+        while (*cursor == ' ' || *cursor == '\t' || *cursor == ',' || *cursor == ';' || *cursor == ':')
+            ++cursor;
+        if (*cursor == '\0')
+            break;
+
+        char *endptr = nullptr;
+        unsigned long value = strtoul(cursor, &endptr, 0);
+        if (endptr == cursor)
+            break;
+        if (value <= 0xffffffffUL)
+            reserved_plane_ids.push_back(static_cast<uint32_t>(value));
+        cursor = endptr;
+    }
+
+    if (!reserved_plane_ids.empty() && !reserved_plane_ids_logged) {
+        fprintf(stderr, "drm_fd_preload: reserving DRM planes");
+        for (uint32_t id : reserved_plane_ids)
+            fprintf(stderr, " %u", id);
+        fprintf(stderr, "\n");
+        reserved_plane_ids_logged = true;
+    }
+}
+
+static bool reserved_planes_active(void) {
+    if (pthread_mutex_lock(&reserved_plane_mutex) != 0)
+        return false;
+    if (!reserved_plane_ids_initialized) {
+        parse_reserved_plane_ids_locked();
+        reserved_plane_ids_initialized = true;
+    }
+    bool active = !reserved_plane_ids.empty();
+    pthread_mutex_unlock(&reserved_plane_mutex);
+    return active;
+}
+
+static bool plane_is_reserved(uint32_t plane_id) {
+    bool reserved = false;
+    if (pthread_mutex_lock(&reserved_plane_mutex) != 0)
+        return false;
+    if (!reserved_plane_ids_initialized) {
+        parse_reserved_plane_ids_locked();
+        reserved_plane_ids_initialized = true;
+    }
+    reserved = std::find(reserved_plane_ids.begin(), reserved_plane_ids.end(), plane_id) != reserved_plane_ids.end();
+    pthread_mutex_unlock(&reserved_plane_mutex);
+    return reserved;
+}
+
+static int ensure_real_drm_symbols(void) {
+    if (!real_drmModeGetPlaneResources_fn) {
+        real_drmModeGetPlaneResources_fn =
+            reinterpret_cast<drmModePlaneResPtr (*)(int)>(dlsym(RTLD_NEXT, "drmModeGetPlaneResources"));
+        if (!real_drmModeGetPlaneResources_fn) {
+            fprintf(stderr, "drm_fd_preload: failed to resolve drmModeGetPlaneResources(): %s\n", dlerror());
+            return -1;
+        }
+    }
+    if (!real_drmModeGetPlane_fn) {
+        real_drmModeGetPlane_fn =
+            reinterpret_cast<drmModePlanePtr (*)(int, uint32_t)>(dlsym(RTLD_NEXT, "drmModeGetPlane"));
+        if (!real_drmModeGetPlane_fn) {
+            fprintf(stderr, "drm_fd_preload: failed to resolve drmModeGetPlane(): %s\n", dlerror());
+            return -1;
+        }
+    }
+    return 0;
+}
+
 extern "C" int open(const char *pathname, int flags, ...) {
     mode_t mode = 0;
     if (flags & O_CREAT) {
@@ -122,4 +208,40 @@ extern "C" int open64(const char *pathname, int flags, ...) {
     if (flags & O_CREAT)
         return real_open64_fn(pathname, flags, mode);
     return real_open64_fn(pathname, flags);
+}
+
+extern "C" drmModePlaneResPtr drmModeGetPlaneResources(int fd) {
+    if (ensure_real_drm_symbols() < 0) {
+        errno = ENOSYS;
+        return nullptr;
+    }
+    drmModePlaneResPtr res = real_drmModeGetPlaneResources_fn(fd);
+    if (!res)
+        return res;
+    if (!reserved_planes_active())
+        return res;
+
+    uint32_t original_count = res->count_planes;
+    uint32_t write_index = 0;
+    for (uint32_t read_index = 0; read_index < original_count; ++read_index) {
+        uint32_t plane_id = res->planes[read_index];
+        if (plane_is_reserved(plane_id))
+            continue;
+        res->planes[write_index++] = plane_id;
+    }
+    res->count_planes = write_index;
+    return res;
+}
+
+extern "C" drmModePlanePtr drmModeGetPlane(int fd, uint32_t plane_id) {
+    if (ensure_real_drm_symbols() < 0) {
+        errno = ENOSYS;
+        return nullptr;
+    }
+    drmModePlanePtr plane = real_drmModeGetPlane_fn(fd, plane_id);
+    if (plane && reserved_planes_active() && plane_is_reserved(plane_id)) {
+        plane->possible_crtcs = 0;
+        plane->count_formats = 0;
+    }
+    return plane;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1050,7 +1050,8 @@ int run_color_cycle(uint16_t mode_width, uint16_t mode_height, uint32_t mode_vre
         }
     }
     struct modeset_output *out = (struct modeset_output *)malloc(sizeof(struct modeset_output));
-    ret = modeset_prepare(fd, out, mode_width, mode_height, mode_vrefresh, DRM_FORMAT_ARGB8888);
+    ret = modeset_prepare(fd, out, mode_width, mode_height, mode_vrefresh, DRM_FORMAT_ARGB8888,
+                          MODESET_PLANE_TYPE_PRIMARY);
     if (ret) {
         close(fd);
         free(out);
@@ -1253,7 +1254,8 @@ int main(int argc, char **argv)
         assert(drm_fd >= 0);
     }
     output_list = (struct modeset_output *)malloc(sizeof(struct modeset_output));
-    ret = modeset_prepare(drm_fd, output_list, mode_width, mode_height, mode_vrefresh, DRM_FORMAT_NV12);
+    ret = modeset_prepare(drm_fd, output_list, mode_width, mode_height, mode_vrefresh, DRM_FORMAT_NV12,
+                          MODESET_PLANE_TYPE_PRIMARY);
     assert(!ret);
 
     ////////////////////////////////// MPI SETUP


### PR DESCRIPTION
## Summary
- add plane type selection helpers so fpvue always claims the primary plane
- detect the primary and overlay plane IDs before launching clients and export them via the environment
- filter reserved plane IDs in the DRM preload library so QOpenHD cannot bind the fpvue primary plane

## Testing
- ./build_debug_cmake.sh

------
https://chatgpt.com/codex/tasks/task_e_68d087970418832f85aa14803c0ea34a