### PR TITLE
Adjust display host startup order and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,23 @@ testing the display stack or sharing the DRM master with another application.
 It now also starts `qopenhd`, rendering the Qt UI on a higher z-position plane
 so the color cycle continues to be visible in the background. The host passes
 `--platform=eglfs` when launching `qopenhd` so it binds directly to the DRM
-overlay plane.
+overlay plane. `qopenhd` is launched first, and the fpvue color-cycle client is
+delayed by 60 seconds so the Qt interface can fully initialize before the
+secondary plane consumer comes online.
 
 Run the host:
 
 ```
 display_host 720p
+```
+
+Positional numeric arguments after the regular options set explicit plane IDs
+for the launched clients. The first ID is applied to the QOpenHD process and
+the second to the fpvue color-cycle client. For example, to force QOpenHD to
+plane `93` and fpvue to plane `105` run:
+
+```
+display_host 93 105
 ```
 
 `display_host` automatically injects the `libdrm_fd_preload.so` shim in front of

--- a/display_host.cpp
+++ b/display_host.cpp
@@ -15,6 +15,8 @@ extern "C" {
 #include <errno.h>
 #include <stdlib.h>
 
+#define DISPLAY_HOST_LOG_PREFIX "display_host: "
+
 static int send_fd(int sock, int fd) {
     struct msghdr msg = {0};
     struct iovec io = { .iov_base = (void*)" ", .iov_len = 1 };
@@ -99,13 +101,13 @@ int receive_fd_from_socket(const char *socket_path) {
 int start_display_host(const char *drm_node, const char *socket_path, int clients, uint16_t mode_width, uint16_t mode_height) {
     int fd;
     if (modeset_open(&fd, drm_node) < 0) {
-        fprintf(stderr, "Failed to open DRM node %s\n", drm_node);
+        fprintf(stderr, DISPLAY_HOST_LOG_PREFIX "Failed to open DRM node %s\n", drm_node);
         return -1;
     }
-    printf("Opened DRM node %s with fd %d\n", drm_node, fd);
+    fprintf(stdout, DISPLAY_HOST_LOG_PREFIX "Opened DRM node %s with fd %d\n", drm_node, fd);
 
     if (mode_width > 0 && mode_height > 0) {
-        printf("Setting mode to %ux%u\n", mode_width, mode_height);
+        fprintf(stdout, DISPLAY_HOST_LOG_PREFIX "Setting mode to %ux%u\n", mode_width, mode_height);
         struct modeset_output *out = (struct modeset_output *)malloc(sizeof(struct modeset_output));
         if (!out) {
             close(fd);
@@ -132,7 +134,7 @@ int start_display_host(const char *drm_node, const char *socket_path, int client
         close(fd);
         return -1;
     }
-    printf("Listening on socket %s for %d clients\n", socket_path, clients);
+    fprintf(stdout, DISPLAY_HOST_LOG_PREFIX "Listening on socket %s for %d clients\n", socket_path, clients);
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
@@ -148,18 +150,18 @@ int start_display_host(const char *drm_node, const char *socket_path, int client
         return -1;
     }
     for (int i = 0; i < clients; ++i) {
-        printf("Waiting for client %d/%d...\n", i + 1, clients);
+        fprintf(stdout, DISPLAY_HOST_LOG_PREFIX "Waiting for client %d/%d...\n", i + 1, clients);
         int client = accept(server, NULL, NULL);
         if (client >= 0) {
-            printf("Client %d connected, sending DRM FD\n", i + 1);
+            fprintf(stdout, DISPLAY_HOST_LOG_PREFIX "Client %d connected, sending DRM FD\n", i + 1);
             send_fd(client, fd);
             close(client);
         } else {
-            perror("accept");
+            fprintf(stderr, DISPLAY_HOST_LOG_PREFIX "accept failed: %s\n", strerror(errno));
         }
     }
     close(server);
-    printf("All clients connected. Display host ready\n");
+    fprintf(stdout, DISPLAY_HOST_LOG_PREFIX "All clients connected. Display host ready\n");
     return fd;
 }
 

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -1,5 +1,6 @@
 #include "display_host.h"
 #include <ctype.h>
+#include <cstdarg>
 #include <fstream>
 #include <iterator>
 #include <limits.h>
@@ -12,6 +13,7 @@
 #include <thread>
 #include <unistd.h>
 #include <vector>
+#include <errno.h>
 
 #ifndef DEFAULT_PRELOAD_PATH
 #define DEFAULT_PRELOAD_PATH ""
@@ -143,6 +145,28 @@ static bool locate_library_in_ldconfig(const char *library_prefix, char *buffer,
 
     pclose(pipe);
     return found;
+}
+
+static constexpr const char kDisplayHostLogPrefix[] = "display_host: ";
+
+static void log_with_prefix(FILE *stream, const char *fmt, va_list args) {
+    fputs(kDisplayHostLogPrefix, stream);
+    vfprintf(stream, fmt, args);
+    fflush(stream);
+}
+
+static void log_info(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    log_with_prefix(stdout, fmt, args);
+    va_end(args);
+}
+
+static void log_error(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    log_with_prefix(stderr, fmt, args);
+    va_end(args);
 }
 
 static int build_preload_path(char *buffer, size_t size) {
@@ -277,20 +301,19 @@ static void pipe_output_to_stream(int fd, FILE *stream, const char *prefix) {
 int main(int argc, char **argv) {
     int stop_sddm_status = system("sudo systemctl stop sddm");
     if (stop_sddm_status == -1) {
-        perror("Failed to execute 'sudo systemctl stop sddm'");
+        log_error("Failed to execute 'sudo systemctl stop sddm': %s\n", strerror(errno));
     } else if (WIFEXITED(stop_sddm_status)) {
         if (WEXITSTATUS(stop_sddm_status) == 0) {
-            printf("Successfully stopped sddm service.\n");
+            log_info("Successfully stopped sddm service.\n");
         } else {
-            fprintf(stderr, "Stopping sddm service exited with status %d.\n", WEXITSTATUS(stop_sddm_status));
+            log_error("Stopping sddm service exited with status %d.\n", WEXITSTATUS(stop_sddm_status));
         }
     } else if (WIFSIGNALED(stop_sddm_status)) {
-        fprintf(stderr, "Stopping sddm service terminated by signal %d.\n", WTERMSIG(stop_sddm_status));
+        log_error("Stopping sddm service terminated by signal %d.\n", WTERMSIG(stop_sddm_status));
     } else {
-        fprintf(stderr, "Stopping sddm service returned unexpected status.\n");
+        log_error("Stopping sddm service returned unexpected status.\n");
     }
 
-    setenv("QT_QPA_EGLFS_KMS_PLANE_INDEX", "3", 1);
     setenv("QT_QPA_EGLFS_KMS_DEBUG", "1", 1);
     setenv("QT_QPA_EGLFS_DEBUG", "1", 1);
 
@@ -298,6 +321,7 @@ int main(int argc, char **argv) {
     const char *socket_path = "/tmp/drm-master";
     int clients = 2;
     uint16_t width = 0, height = 0;
+    std::vector<int> forced_planes;
 
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "720p") == 0) {
@@ -313,42 +337,50 @@ int main(int argc, char **argv) {
         } else if (strcmp(argv[i], "--clients") == 0 && i + 1 < argc) {
             clients = atoi(argv[++i]);
         } else {
-            fprintf(stderr, "Usage: %s [720p|1080p] [--socket path] [--drm node] [--clients n]\n", argv[0]);
-            return 1;
+            char *end = nullptr;
+            long value = strtol(argv[i], &end, 10);
+            if (argv[i][0] != '\0' && end && *end == '\0') {
+                forced_planes.push_back(static_cast<int>(value));
+            } else {
+                log_error("Usage: %s [720p|1080p] [--socket path] [--drm node] [--clients n] [plane0 [plane1 ...]]\n", argv[0]);
+                return 1;
+            }
         }
     }
 
     if (clients < 2)
         clients = 2;
 
-    pid_t pid = fork();
-    if (pid == 0) {
-        sleep(1);
-        configure_shared_drm_environment(socket_path, drm_node);
-        setenv("FPVUE_COLOR_CYCLE_ZPOS", "0", 1);
-        execlp("fpvue", "fpvue", "--color-cycle", NULL);
-        perror("execlp fpvue");
-        return 1;
-    }
+    std::string qopenhd_plane = forced_planes.size() > 0 ? std::to_string(forced_planes[0]) : std::string("3");
+    std::string fpvue_plane = forced_planes.size() > 1 ? std::to_string(forced_planes[1]) : std::string("0");
 
-    int stdout_pipe[2] = {-1, -1};
-    int stderr_pipe[2] = {-1, -1};
-    bool capture_qopenhd_logs = pipe(stdout_pipe) == 0 && pipe(stderr_pipe) == 0;
+    int qopenhd_stdout_pipe[2] = {-1, -1};
+    int qopenhd_stderr_pipe[2] = {-1, -1};
+    bool capture_qopenhd_logs = pipe(qopenhd_stdout_pipe) == 0 && pipe(qopenhd_stderr_pipe) == 0;
     if (!capture_qopenhd_logs) {
-        if (stdout_pipe[0] >= 0) {
-            close(stdout_pipe[0]);
-            close(stdout_pipe[1]);
+        if (qopenhd_stdout_pipe[0] >= 0) {
+            close(qopenhd_stdout_pipe[0]);
+            close(qopenhd_stdout_pipe[1]);
         }
-        if (stderr_pipe[0] >= 0) {
-            close(stderr_pipe[0]);
-            close(stderr_pipe[1]);
+        if (qopenhd_stderr_pipe[0] >= 0) {
+            close(qopenhd_stderr_pipe[0]);
+            close(qopenhd_stderr_pipe[1]);
         }
     }
 
     pid_t qopenhd_pid = fork();
     if (qopenhd_pid == 0) {
         sleep(2);
+        if (capture_qopenhd_logs) {
+            close(qopenhd_stdout_pipe[0]);
+            close(qopenhd_stderr_pipe[0]);
+            dup2(qopenhd_stdout_pipe[1], STDOUT_FILENO);
+            dup2(qopenhd_stderr_pipe[1], STDERR_FILENO);
+            close(qopenhd_stdout_pipe[1]);
+            close(qopenhd_stderr_pipe[1]);
+        }
         configure_shared_drm_environment(socket_path, drm_node);
+        setenv("QT_QPA_EGLFS_KMS_PLANE_INDEX", qopenhd_plane.c_str(), 1);
         const char *current_platform = getenv("QT_QPA_PLATFORM");
         if (!current_platform || strcmp(current_platform, "eglfs") != 0)
             setenv("QT_QPA_PLATFORM", "eglfs", 1);
@@ -368,15 +400,6 @@ int main(int argc, char **argv) {
         const char *kms_atomic = getenv("QT_QPA_EGLFS_KMS_ATOMIC");
         if (!kms_atomic || kms_atomic[0] == '\0')
             setenv("QT_QPA_EGLFS_KMS_ATOMIC", "1", 1);
-
-        if (capture_qopenhd_logs) {
-            close(stdout_pipe[0]);
-            close(stderr_pipe[0]);
-            dup2(stdout_pipe[1], STDOUT_FILENO);
-            dup2(stderr_pipe[1], STDERR_FILENO);
-            close(stdout_pipe[1]);
-            close(stderr_pipe[1]);
-        }
 
         setenv("QT_LOGGING_TO_CONSOLE", "1", 1);
         ensure_preload_in_environment("QOpenHD");
@@ -402,43 +425,89 @@ int main(int argc, char **argv) {
                 drm_device ? drm_device : "(unset)");
         fflush(stderr);
         execlp("QOpenHD", "QOpenHD", "--platform=eglfs", NULL);
-        perror("execlp qopenhd");
+        fprintf(stderr, "Failed to launch QOpenHD: %s\n", strerror(errno));
         return 1;
     }
 
     if (capture_qopenhd_logs) {
-        close(stdout_pipe[1]);
-        close(stderr_pipe[1]);
-        pipe_output_to_stream(stdout_pipe[0], stdout, "[QOpenHD] ");
-        pipe_output_to_stream(stderr_pipe[0], stderr, "[QOpenHD] ");
+        close(qopenhd_stdout_pipe[1]);
+        close(qopenhd_stderr_pipe[1]);
+        pipe_output_to_stream(qopenhd_stdout_pipe[0], stdout, "qopenhd: ");
+        pipe_output_to_stream(qopenhd_stderr_pipe[0], stderr, "qopenhd: ");
     }
 
-    printf("Starting display host with DRM node %s, socket %s, expecting %d clients", drm_node, socket_path, clients);
-    if (width > 0 && height > 0) {
-        printf(", forcing mode %ux%u", width, height);
+    log_info("Delaying fpvue color cycle launch by 60 seconds to allow QOpenHD to initialize first.\n");
+
+    int fpvue_stdout_pipe[2] = {-1, -1};
+    int fpvue_stderr_pipe[2] = {-1, -1};
+    bool capture_fpvue_logs = pipe(fpvue_stdout_pipe) == 0 && pipe(fpvue_stderr_pipe) == 0;
+    if (!capture_fpvue_logs) {
+        if (fpvue_stdout_pipe[0] >= 0) {
+            close(fpvue_stdout_pipe[0]);
+            close(fpvue_stdout_pipe[1]);
+        }
+        if (fpvue_stderr_pipe[0] >= 0) {
+            close(fpvue_stderr_pipe[0]);
+            close(fpvue_stderr_pipe[1]);
+        }
     }
-    printf("\n");
-    printf("Launched fpvue color cycle client as PID %d.\n", pid);
-    printf("Launched QOpenHD client as PID %d using overlay plane.\n", qopenhd_pid);
+
+    pid_t fpvue_pid = fork();
+    if (fpvue_pid == 0) {
+        sleep(60);
+        if (capture_fpvue_logs) {
+            close(fpvue_stdout_pipe[0]);
+            close(fpvue_stderr_pipe[0]);
+            dup2(fpvue_stdout_pipe[1], STDOUT_FILENO);
+            dup2(fpvue_stderr_pipe[1], STDERR_FILENO);
+            close(fpvue_stdout_pipe[1]);
+            close(fpvue_stderr_pipe[1]);
+        }
+        configure_shared_drm_environment(socket_path, drm_node);
+        setenv("FPVUE_COLOR_CYCLE_ZPOS", "0", 1);
+        setenv("FPVUE_FORCED_PLANE_ID", fpvue_plane.c_str(), 1);
+        execlp("fpvue", "fpvue", "--color-cycle", NULL);
+        fprintf(stderr, "Failed to launch fpvue color cycle: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (capture_fpvue_logs) {
+        close(fpvue_stdout_pipe[1]);
+        close(fpvue_stderr_pipe[1]);
+        pipe_output_to_stream(fpvue_stdout_pipe[0], stdout, "fpvue: ");
+        pipe_output_to_stream(fpvue_stderr_pipe[0], stderr, "fpvue: ");
+    }
+
+    setenv("FPVUE_LOG_PREFIX", kDisplayHostLogPrefix, 1);
+
+    if (width > 0 && height > 0) {
+        log_info("Starting display host with DRM node %s, socket %s, expecting %d clients and forcing mode %ux%u.\n",
+                 drm_node, socket_path, clients, width, height);
+    } else {
+        log_info("Starting display host with DRM node %s, socket %s, expecting %d clients.\n", drm_node, socket_path,
+                 clients);
+    }
+    log_info("Configured QOpenHD plane %s and launched client as PID %d.\n", qopenhd_plane.c_str(), qopenhd_pid);
+    log_info("Configured fpvue plane %s and launched color cycle client as PID %d.\n", fpvue_plane.c_str(), fpvue_pid);
     std::thread([qopenhd_pid]() {
         int status = 0;
         pid_t result = waitpid(qopenhd_pid, &status, 0);
         if (result > 0) {
             if (WIFEXITED(status)) {
-                fprintf(stderr, "QOpenHD exited with status %d.\n", WEXITSTATUS(status));
+                log_error("QOpenHD exited with status %d.\n", WEXITSTATUS(status));
             } else if (WIFSIGNALED(status)) {
-                fprintf(stderr, "QOpenHD terminated by signal %d.\n", WTERMSIG(status));
+                log_error("QOpenHD terminated by signal %d.\n", WTERMSIG(status));
             }
         }
     }).detach();
-    printf("Qt applications launched by the host automatically share DRM master access via %s.\n", socket_path);
+    log_info("Qt applications launched by the host automatically share DRM master access via %s.\n", socket_path);
 
     int fd = start_display_host(drm_node, socket_path, clients, width, height);
     if (fd < 0) {
-        fprintf(stderr, "Failed to start display host\n");
+        log_error("Failed to start display host\n");
         return 1;
     }
-    printf("Display host running. DRM FD %d shared on %s\n", fd, socket_path);
+    log_info("Display host running. DRM FD %d shared on %s\n", fd, socket_path);
     while (1) {
         sleep(60);
     }

--- a/drm.c
+++ b/drm.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -14,6 +15,28 @@
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>
 #include <assert.h>
+
+static int drm_prefixed_vfprintf(FILE *stream, const char *fmt, va_list args)
+{
+        const char *prefix = getenv("FPVUE_LOG_PREFIX");
+        int result = 0;
+        if (prefix && *prefix)
+                result += fputs(prefix, stream);
+        result += vfprintf(stream, fmt, args);
+        return result;
+}
+
+static int drm_prefixed_fprintf(FILE *stream, const char *fmt, ...)
+{
+        va_list args;
+        va_start(args, fmt);
+        int result = drm_prefixed_vfprintf(stream, fmt, args);
+        va_end(args);
+        return result;
+}
+
+#define fprintf(stream, fmt, ...) drm_prefixed_fprintf(stream, fmt, ##__VA_ARGS__)
+#define printf(fmt, ...) drm_prefixed_fprintf(stdout, fmt, ##__VA_ARGS__)
 
 static bool get_plane_type_value(int fd, uint32_t plane_id, uint64_t *type_out)
 {
@@ -247,7 +270,14 @@ int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *pl
         drmModePlaneResPtr plane_res;
         bool found_plane = false;
         int best_priority = 3;
-        int i, ret = -EINVAL;
+        const char *forced_plane_env = getenv("FPVUE_FORCED_PLANE_ID");
+        int forced_plane_id = -1;
+        if (forced_plane_env && forced_plane_env[0] != '\0') {
+                forced_plane_id = atoi(forced_plane_env);
+                if (forced_plane_id <= 0)
+                        forced_plane_id = -1;
+        }
+        int i, ret = forced_plane_id > 0 ? -ENOENT : -EINVAL;
 
         plane_res = drmModeGetPlaneResources(fd);
         if (!plane_res) {
@@ -259,6 +289,8 @@ int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *pl
         bool prefer_primary = (plane_format == DRM_FORMAT_ARGB8888);
         for (i = 0; i < plane_res->count_planes; i++) {
                 int plane_id = plane_res->planes[i];
+                if (forced_plane_id > 0 && plane_id != forced_plane_id)
+                        continue;
                 bool matches = false;
                 int priority = 2;
 
@@ -304,6 +336,9 @@ int modeset_find_plane(int fd, struct modeset_output *out, struct drm_object *pl
         }
 
         drmModeFreePlaneResources(plane_res);
+
+        if (forced_plane_id > 0 && !found_plane)
+                fprintf(stderr, "Failed to locate forced plane %d for video\n", forced_plane_id);
 
         return ret;
 }


### PR DESCRIPTION
## Summary
- launch QOpenHD before the fpvue color-cycle client, delay the secondary launch by 60 seconds, and prefix captured logs with their client names
- allow positional plane IDs to force QOpenHD and fpvue onto specific DRM planes while propagating the selection into the DRM helper
- prefix display_host logging (including DRM helpers) and document the startup order and plane override options in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d11537e784832fbdb7817cbccc40af