### PR TITLE
Fix DRM plane env setup to use active CRTC id

### DIFF
--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -234,14 +234,18 @@ static bool plane_supports_argb8888(const drmModePlanePtr plane) {
     return false;
 }
 
-static bool determine_active_crtc_index(int fd, uint32_t *crtc_index_out) {
+static bool determine_active_crtc(int fd, uint32_t *crtc_index_out, uint32_t *crtc_id_out) {
     drmModeRes *resources = drmModeGetResources(fd);
     if (!resources)
         return false;
 
     bool found = false;
     uint32_t crtc_index = 0;
+    uint32_t crtc_id = 0;
     const bool has_crtcs = resources->count_crtcs > 0;
+
+    if (has_crtcs)
+        crtc_id = resources->crtcs[0];
 
     for (int i = 0; i < resources->count_connectors && !found; ++i) {
         drmModeConnector *connector = drmModeGetConnector(fd, resources->connectors[i]);
@@ -255,10 +259,11 @@ static bool determine_active_crtc_index(int fd, uint32_t *crtc_index_out) {
                 if (!encoder)
                     continue;
 
-                uint32_t crtc_id = encoder->crtc_id;
+                uint32_t encoder_crtc_id = encoder->crtc_id;
                 for (int k = 0; k < resources->count_crtcs; ++k) {
-                    if (resources->crtcs[k] == static_cast<int>(crtc_id)) {
+                    if (resources->crtcs[k] == encoder_crtc_id) {
                         crtc_index = static_cast<uint32_t>(k);
+                        crtc_id = resources->crtcs[k];
                         found = true;
                         break;
                     }
@@ -271,8 +276,10 @@ static bool determine_active_crtc_index(int fd, uint32_t *crtc_index_out) {
         drmModeFreeConnector(connector);
     }
 
-    if (!found && has_crtcs)
+    if (!found && has_crtcs) {
         crtc_index = 0;
+        crtc_id = resources->crtcs[0];
+    }
 
     bool success = found || has_crtcs;
     drmModeFreeResources(resources);
@@ -280,6 +287,8 @@ static bool determine_active_crtc_index(int fd, uint32_t *crtc_index_out) {
     if (success) {
         if (crtc_index_out)
             *crtc_index_out = crtc_index;
+        if (crtc_id_out)
+            *crtc_id_out = crtc_id;
         return true;
     }
 
@@ -339,7 +348,8 @@ static bool build_planes_for_crtc_value(const char *drm_node, std::string &value
         fprintf(stderr, "Warning: Failed to enable universal planes capability on %s\n", drm_node);
 
     uint32_t crtc_index = 0;
-    if (!determine_active_crtc_index(fd, &crtc_index)) {
+    uint32_t crtc_id = 0;
+    if (!determine_active_crtc(fd, &crtc_index, &crtc_id)) {
         fprintf(stderr, "Failed to determine active CRTC for %s\n", drm_node);
         close(fd);
         return false;
@@ -360,7 +370,7 @@ static bool build_planes_for_crtc_value(const char *drm_node, std::string &value
     planes.push_back(selection.overlay_id);
 
     std::ostringstream oss;
-    oss << crtc_index << ":";
+    oss << crtc_id << ":";
     for (size_t i = 0; i < planes.size(); ++i) {
         if (i > 0)
             oss << ",";


### PR DESCRIPTION
## Summary
- determine the active CRTC's ID alongside its index when scanning connectors
- populate QT_QPA_EGLFS_KMS_PLANES_FOR_CRTCS with the active CRTC ID instead of the index so Qt receives the correct mapping

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68d13e0152b0832f93c0f768b23f14de