### PR TITLE
Add Cedar decoder fallback when Rockchip MPP is unavailable

### DIFF
--- a/allwinnerv4l2display.cpp
+++ b/allwinnerv4l2display.cpp
@@ -11,33 +11,61 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>
+#include <cerrno>
+#include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <vector>
 
 namespace {
-constexpr int kVideoWidth = 1280;
-constexpr int kVideoHeight = 720;
 constexpr int kOutputBuffers = 4;
 constexpr int kCaptureBuffers = 4;
 }
 
-AllwinnerV4L2Display::AllwinnerV4L2Display(int udp_port, bool h265)
-    : m_port(udp_port), m_h265(h265) {}
+AllwinnerV4L2Display::AllwinnerV4L2Display(int udp_port,
+                                           bool h265,
+                                           uint32_t mode_width,
+                                           uint32_t mode_height,
+                                           uint32_t mode_vrefresh)
+    : m_port(udp_port),
+      m_h265(h265),
+      m_mode_width(mode_width ? mode_width : 1280),
+      m_mode_height(mode_height ? mode_height : 720),
+      m_mode_vrefresh(mode_vrefresh ? mode_vrefresh : 60) {
+  if (m_port < 0) {
+    m_input_mode = InputMode::StdIn;
+    m_input_fd = STDIN_FILENO;
+  }
+}
+
+void AllwinnerV4L2Display::set_external_drm_fd(int fd, bool take_ownership) {
+  m_drm_fd = fd;
+  m_take_ownership_of_drm_fd = take_ownership;
+}
+
+void AllwinnerV4L2Display::override_input_mode(InputMode mode) {
+  m_input_mode = mode;
+  if (mode == InputMode::StdIn && m_input_fd < 0) {
+    m_input_fd = STDIN_FILENO;
+  }
+}
 
 AllwinnerV4L2Display::~AllwinnerV4L2Display() { stop(); }
 
 bool AllwinnerV4L2Display::start() {
   if (!setup_network()) {
     std::cerr << "Failed to setup network" << std::endl;
+    stop();
     return false;
   }
   if (!setup_drm()) {
     std::cerr << "Failed to setup DRM" << std::endl;
+    stop();
     return false;
   }
   if (!setup_v4l2()) {
     std::cerr << "Failed to setup V4L2" << std::endl;
+    stop();
     return false;
   }
   m_running = true;
@@ -46,11 +74,13 @@ bool AllwinnerV4L2Display::start() {
 }
 
 void AllwinnerV4L2Display::stop() {
-  if (!m_running) return;
-  m_running = false;
-  if (m_thread.joinable()) m_thread.join();
+  if (m_running) {
+    m_running = false;
+    if (m_thread.joinable())
+      m_thread.join();
+  }
 
-  if (m_sock >= 0) {
+  if (m_sock >= 0 && m_input_mode == InputMode::UDP) {
     close(m_sock);
     m_sock = -1;
   }
@@ -63,13 +93,26 @@ void AllwinnerV4L2Display::stop() {
     m_v4l2_fd = -1;
   }
   if (m_drm_fd >= 0) {
-    modeset_cleanup(m_drm_fd, &m_output);
-    close(m_drm_fd);
+    if (m_drm_prepared) {
+      modeset_cleanup(m_drm_fd, &m_output);
+      m_drm_prepared = false;
+    }
+    if (m_take_ownership_of_drm_fd) {
+      close(m_drm_fd);
+    }
     m_drm_fd = -1;
   }
 }
 
 bool AllwinnerV4L2Display::setup_network() {
+  if (m_input_mode == InputMode::StdIn) {
+    m_sock = -1;
+    if (m_input_fd < 0)
+      m_input_fd = STDIN_FILENO;
+    printf("Allwinner cedar path reading compressed video from stdin.\n");
+    return true;
+  }
+
   m_sock = socket(AF_INET, SOCK_DGRAM, 0);
   if (m_sock < 0) {
     perror("socket");
@@ -83,14 +126,26 @@ bool AllwinnerV4L2Display::setup_network() {
     perror("bind");
     return false;
   }
+  printf("Allwinner cedar path listening on UDP port %d.\n", m_port);
   return true;
 }
 
 bool AllwinnerV4L2Display::setup_drm() {
-  if (modeset_open(&m_drm_fd, "/dev/dri/card0") < 0) return false;
-  if (modeset_prepare(m_drm_fd, &m_output, kVideoWidth, kVideoHeight, 60, DRM_FORMAT_NV12,
-                      MODESET_PLANE_TYPE_PRIMARY) < 0)
+  if (m_drm_fd < 0) {
+    if (modeset_open(&m_drm_fd, "/dev/dri/card0") < 0) {
+      return false;
+    }
+  }
+  if (modeset_prepare(m_drm_fd,
+                      &m_output,
+                      m_mode_width,
+                      m_mode_height,
+                      m_mode_vrefresh,
+                      DRM_FORMAT_NV12,
+                      MODESET_PLANE_TYPE_PRIMARY) < 0) {
     return false;
+  }
+  m_drm_prepared = true;
   return true;
 }
 
@@ -104,8 +159,8 @@ bool AllwinnerV4L2Display::setup_v4l2() {
   struct v4l2_format fmt;
   memset(&fmt, 0, sizeof(fmt));
   fmt.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
-  fmt.fmt.pix_mp.width = kVideoWidth;
-  fmt.fmt.pix_mp.height = kVideoHeight;
+  fmt.fmt.pix_mp.width = m_mode_width;
+  fmt.fmt.pix_mp.height = m_mode_height;
   fmt.fmt.pix_mp.pixelformat =
       m_h265 ? V4L2_PIX_FMT_HEVC_SLICE : V4L2_PIX_FMT_H264_SLICE;
   fmt.fmt.pix_mp.num_planes = 1;
@@ -116,8 +171,8 @@ bool AllwinnerV4L2Display::setup_v4l2() {
 
   memset(&fmt, 0, sizeof(fmt));
   fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  fmt.fmt.pix_mp.width = kVideoWidth;
-  fmt.fmt.pix_mp.height = kVideoHeight;
+  fmt.fmt.pix_mp.width = m_mode_width;
+  fmt.fmt.pix_mp.height = m_mode_height;
   fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_NV12M;
   fmt.fmt.pix_mp.num_planes = 2;
   if (ioctl(m_v4l2_fd, VIDIOC_S_FMT, &fmt) < 0) {
@@ -212,7 +267,7 @@ bool AllwinnerV4L2Display::setup_v4l2() {
                            fmt.fmt.pix_mp.plane_fmt[1].bytesperline, 0, 0};
     uint32_t offsets[4] = {planes[0].data_offset, planes[1].data_offset, 0, 0};
     uint32_t fb_id = 0;
-    if (drmModeAddFB2(m_drm_fd, kVideoWidth, kVideoHeight, DRM_FORMAT_NV12,
+    if (drmModeAddFB2(m_drm_fd, m_mode_width, m_mode_height, DRM_FORMAT_NV12,
                       handles, pitches, offsets, &fb_id, 0) != 0) {
       perror("AddFB2");
       close(prime_fd);
@@ -240,12 +295,27 @@ void AllwinnerV4L2Display::decode_loop() {
   uint32_t output_index = 0;
 
   while (m_running) {
-    ssize_t rx = recv(m_sock, rx_buffer.data(), rx_buffer.size(), 0);
-    if (rx <= 0) continue;
+    ssize_t rx = 0;
+    uint8_t *nal = nullptr;
     uint32_t nal_size = 0;
-    uint8_t *nal =
-        decode_frame(rx_buffer.data(), rx, 0, nal_buffer.data(), &nal_size);
-    if (!nal) continue;
+    if (m_input_mode == InputMode::UDP) {
+      rx = recv(m_sock, rx_buffer.data(), rx_buffer.size(), 0);
+      if (rx <= 0)
+        continue;
+      nal = decode_frame(rx_buffer.data(), rx, 0, nal_buffer.data(), &nal_size);
+      if (!nal)
+        continue;
+    } else {
+      rx = read(m_input_fd, nal_buffer.data(), nal_buffer.size());
+      if (rx <= 0) {
+        if (rx < 0 && errno == EINTR)
+          continue;
+        usleep(5 * 1000);
+        continue;
+      }
+      nal = nal_buffer.data();
+      nal_size = static_cast<uint32_t>(rx);
+    }
 
     struct v4l2_buffer obuf;
     struct v4l2_plane oplanes[1];

--- a/allwinnerv4l2display.h
+++ b/allwinnerv4l2display.h
@@ -18,7 +18,18 @@ extern "C" {
  */
 class AllwinnerV4L2Display {
 public:
-  AllwinnerV4L2Display(int udp_port, bool h265);
+  enum class InputMode {
+    UDP,
+    StdIn
+  };
+
+  AllwinnerV4L2Display(int udp_port,
+                       bool h265,
+                       uint32_t mode_width = 1280,
+                       uint32_t mode_height = 720,
+                       uint32_t mode_vrefresh = 60);
+  void set_external_drm_fd(int fd, bool take_ownership);
+  void override_input_mode(InputMode mode);
   ~AllwinnerV4L2Display();
 
   // Start the decoding/ display thread. Returns true on success.
@@ -38,8 +49,16 @@ private:
   std::thread m_thread;
 
   int m_sock{-1};
+  int m_input_fd{-1};
   int m_v4l2_fd{-1};
   int m_drm_fd{-1};
+  bool m_take_ownership_of_drm_fd{true};
+  InputMode m_input_mode{InputMode::UDP};
+  bool m_drm_prepared{false};
+
+  uint32_t m_mode_width{1280};
+  uint32_t m_mode_height{720};
+  uint32_t m_mode_vrefresh{60};
 
   struct modeset_output m_output{};
 

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -498,7 +498,7 @@ int main(int argc, char **argv) {
                 std::string("gst-launch-1.0 -q filesrc location=") + debug_sample_path +
                 " ! qtdemux name=demux demux.video_0 ! h264parse config-interval=1 ! "
                 "video/x-h264,stream-format=byte-stream,alignment=au ! queue ! fdsink fd=1 sync=false | "
-                "fpvue --screen-mode 1280x720@60";
+                "fpvue --screen-mode 1280x720@60 --cedar";
 
             execlp("sh", "sh", "-c", pipeline_command.c_str(), (char *)NULL);
             perror("execlp sample video pipeline");

--- a/main.cpp
+++ b/main.cpp
@@ -951,6 +951,8 @@ void printHelp() {
     "\n"
     "    --aw-display        - use V4L2 stateless decode and sunxi-drm display\n"
     "\n"
+    "    --cedar            - force Cedar hardware decode fallback path\n"
+    "\n"
     "    --color-cycle      - display green, red and blue test screen\n"
     "\n"
     "    --rmode      - different rendering modes for development \n"
@@ -1023,6 +1025,7 @@ bool x20_force=false;
 bool x20_auto=false;
 bool aw_display=false;
 bool color_cycle=false;
+bool force_cedar=false;
 
 static bool read_env_uint32(const char *name, uint32_t &value) {
     const char *env = getenv(name);
@@ -1298,6 +1301,10 @@ int main(int argc, char **argv)
         aw_display=true;
         continue;
     }
+    __OnArgument("--cedar") {
+        force_cedar=true;
+        continue;
+    }
     __OnArgument("--color-cycle") {
         color_cycle=true;
         continue;
@@ -1486,7 +1493,49 @@ int main(int argc, char **argv)
 
     return 0;
 #else
-    fprintf(stderr, "Rockchip support not available in this build\n");
-    return 1;
+    if (!force_cedar && !aw_display) {
+        printf("Rockchip MPP not available; enabling Cedar hardware decode path.\n");
+    } else {
+        printf("Using Cedar hardware decode path.\n");
+    }
+
+    if (x20_auto || x20_force) {
+        fprintf(stderr, "Warning: x20 specific options are ignored on Cedar builds.\n");
+    }
+
+    AllwinnerV4L2Display::InputMode input_mode =
+        (udp_port >= 0) ? AllwinnerV4L2Display::InputMode::UDP
+                        : AllwinnerV4L2Display::InputMode::StdIn;
+
+    uint32_t cedar_width = mode_width ? mode_width : 1280;
+    uint32_t cedar_height = mode_height ? mode_height : 720;
+    uint32_t cedar_vrefresh = mode_vrefresh ? mode_vrefresh : 60;
+
+    AllwinnerV4L2Display display(udp_port, decode_h265, cedar_width, cedar_height, cedar_vrefresh);
+    display.override_input_mode(input_mode);
+
+    int cedar_drm_fd = -1;
+    const char* fd_socket = getenv("FPVUE_DRM_FD_SOCKET");
+    if (fd_socket) {
+        cedar_drm_fd = receive_fd_from_socket(fd_socket);
+        if (cedar_drm_fd < 0) {
+            fprintf(stderr, "Failed to receive DRM FD from socket %s\n", fd_socket);
+            return 1;
+        }
+        display.set_external_drm_fd(cedar_drm_fd, true);
+    }
+
+    if (!display.start()) {
+        fprintf(stderr, "Failed to start Cedar decoder/display pipeline.\n");
+        display.stop();
+        return 1;
+    }
+
+    while (!signal_flag) {
+        sleep(1);
+    }
+
+    display.stop();
+    return 0;
 #endif
 }


### PR DESCRIPTION
## Summary
- extend the Allwinner V4L2 display helper so it can reuse external DRM FDs, read compressed frames from stdin, and track dynamic video modes
- add a Cedar hardware decode fallback path in `fpvue` with a new `--cedar` flag so non-Rockchip builds automatically use the Allwinner pipeline
- ensure the display host debug sample invokes `fpvue` with the Cedar backend for consistent playback

## Testing
- cmake -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68ffb83d29bc832fa1a5584f17ea0925