### PR TITLE
Support Cedar H.264 scaling on high-res displays

### DIFF
--- a/allwinnerv4l2display.cpp
+++ b/allwinnerv4l2display.cpp
@@ -29,9 +29,12 @@ AllwinnerV4L2Display::AllwinnerV4L2Display(int udp_port,
                                            uint32_t mode_vrefresh)
     : m_port(udp_port),
       m_h265(h265),
-      m_mode_width(mode_width ? mode_width : 1280),
-      m_mode_height(mode_height ? mode_height : 720),
-      m_mode_vrefresh(mode_vrefresh ? mode_vrefresh : 60) {
+      m_stream_width(mode_width ? mode_width : 1280),
+      m_stream_height(mode_height ? mode_height : 720),
+      m_stream_vrefresh(mode_vrefresh ? mode_vrefresh : 60),
+      m_display_width(mode_width),
+      m_display_height(mode_height),
+      m_display_vrefresh(mode_vrefresh) {
   if (m_port < 0) {
     m_input_mode = InputMode::StdIn;
     m_input_fd = STDIN_FILENO;
@@ -68,6 +71,7 @@ bool AllwinnerV4L2Display::start() {
     stop();
     return false;
   }
+  m_modeset_initialized = false;
   m_running = true;
   m_thread = std::thread(&AllwinnerV4L2Display::decode_loop, this);
   return true;
@@ -79,6 +83,7 @@ void AllwinnerV4L2Display::stop() {
     if (m_thread.joinable())
       m_thread.join();
   }
+  m_modeset_initialized = false;
 
   if (m_sock >= 0 && m_input_mode == InputMode::UDP) {
     close(m_sock);
@@ -94,6 +99,10 @@ void AllwinnerV4L2Display::stop() {
   }
   if (m_drm_fd >= 0) {
     if (m_drm_prepared) {
+      if (m_output.video_request) {
+        drmModeAtomicFree(m_output.video_request);
+        m_output.video_request = nullptr;
+      }
       modeset_cleanup(m_drm_fd, &m_output);
       m_drm_prepared = false;
     }
@@ -138,9 +147,9 @@ bool AllwinnerV4L2Display::setup_drm() {
   }
   if (modeset_prepare(m_drm_fd,
                       &m_output,
-                      m_mode_width,
-                      m_mode_height,
-                      m_mode_vrefresh,
+                      m_display_width,
+                      m_display_height,
+                      m_display_vrefresh,
                       DRM_FORMAT_NV12,
                       MODESET_PLANE_TYPE_PRIMARY) < 0) {
     return false;
@@ -159,8 +168,8 @@ bool AllwinnerV4L2Display::setup_v4l2() {
   struct v4l2_format fmt;
   memset(&fmt, 0, sizeof(fmt));
   fmt.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
-  fmt.fmt.pix_mp.width = m_mode_width;
-  fmt.fmt.pix_mp.height = m_mode_height;
+  fmt.fmt.pix_mp.width = m_stream_width;
+  fmt.fmt.pix_mp.height = m_stream_height;
   fmt.fmt.pix_mp.pixelformat =
       m_h265 ? V4L2_PIX_FMT_HEVC_SLICE : V4L2_PIX_FMT_H264_SLICE;
   fmt.fmt.pix_mp.num_planes = 1;
@@ -171,14 +180,16 @@ bool AllwinnerV4L2Display::setup_v4l2() {
 
   memset(&fmt, 0, sizeof(fmt));
   fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
-  fmt.fmt.pix_mp.width = m_mode_width;
-  fmt.fmt.pix_mp.height = m_mode_height;
+  fmt.fmt.pix_mp.width = m_stream_width;
+  fmt.fmt.pix_mp.height = m_stream_height;
   fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_NV12M;
   fmt.fmt.pix_mp.num_planes = 2;
   if (ioctl(m_v4l2_fd, VIDIOC_S_FMT, &fmt) < 0) {
     perror("S_FMT capture");
     return false;
   }
+  m_stream_width = fmt.fmt.pix_mp.width;
+  m_stream_height = fmt.fmt.pix_mp.height;
 
   struct v4l2_requestbuffers req;
   memset(&req, 0, sizeof(req));
@@ -267,7 +278,7 @@ bool AllwinnerV4L2Display::setup_v4l2() {
                            fmt.fmt.pix_mp.plane_fmt[1].bytesperline, 0, 0};
     uint32_t offsets[4] = {planes[0].data_offset, planes[1].data_offset, 0, 0};
     uint32_t fb_id = 0;
-    if (drmModeAddFB2(m_drm_fd, m_mode_width, m_mode_height, DRM_FORMAT_NV12,
+    if (drmModeAddFB2(m_drm_fd, m_stream_width, m_stream_height, DRM_FORMAT_NV12,
                       handles, pitches, offsets, &fb_id, 0) != 0) {
       perror("AddFB2");
       close(prime_fd);
@@ -343,7 +354,26 @@ void AllwinnerV4L2Display::decode_loop() {
     cbuf.m.planes = cplanes;
     if (ioctl(m_v4l2_fd, VIDIOC_DQBUF, &cbuf) == 0) {
       int fb_id = m_capture_fbs[cbuf.index];
-      extra_modeset_set_fb(m_drm_fd, &m_output, &m_output.video_plane, fb_id);
+      bool submit_via_set_fb = true;
+      if (!m_modeset_initialized && m_output.video_request) {
+        int ret = modeset_perform_modeset(m_drm_fd,
+                                          &m_output,
+                                          m_output.video_request,
+                                          &m_output.video_plane,
+                                          fb_id,
+                                          static_cast<int>(m_stream_width),
+                                          static_cast<int>(m_stream_height),
+                                          0);
+        if (ret == 0) {
+          m_modeset_initialized = true;
+          submit_via_set_fb = false;
+        } else {
+          std::cerr << "Failed to perform initial modeset for Cedar display path." << std::endl;
+        }
+      }
+      if (submit_via_set_fb) {
+        extra_modeset_set_fb(m_drm_fd, &m_output, &m_output.video_plane, fb_id);
+      }
       ioctl(m_v4l2_fd, VIDIOC_QBUF, &cbuf);
     }
 

--- a/allwinnerv4l2display.h
+++ b/allwinnerv4l2display.h
@@ -56,9 +56,13 @@ private:
   InputMode m_input_mode{InputMode::UDP};
   bool m_drm_prepared{false};
 
-  uint32_t m_mode_width{1280};
-  uint32_t m_mode_height{720};
-  uint32_t m_mode_vrefresh{60};
+  uint32_t m_stream_width{1280};
+  uint32_t m_stream_height{720};
+  uint32_t m_stream_vrefresh{60};
+  uint32_t m_display_width{0};
+  uint32_t m_display_height{0};
+  uint32_t m_display_vrefresh{0};
+  bool m_modeset_initialized{false};
 
   struct modeset_output m_output{};
 

--- a/drm.c
+++ b/drm.c
@@ -488,25 +488,82 @@ struct modeset_output *modeset_output_create(int fd, drmModeRes *res, drmModeCon
 		goto out_error;
 	}
 
-	int fc = 0;
-	if (mode_width>0 && mode_height>0 && mode_vrefresh>0) {
-		fc = -1;
-		printf( "Available modes:\n");
-		for (int i = 0; i < conn->count_modes; i++ ) {
-			printf( "%d : %dx%d@%d\n",i, conn->modes[i].hdisplay, conn->modes[i].vdisplay , conn->modes[i].vrefresh );
-			if (conn->modes[i].hdisplay == mode_width &&
-			conn->modes[i].vdisplay == mode_height &&
-			conn->modes[i].vrefresh == mode_vrefresh
-			) {
-				fc = i;
-			}
-		}
-		if (fc < 0) {
-			fprintf(stderr, "couldn't find a matching mode for %dx%d@%d\n", mode_width , mode_height , mode_vrefresh);
-			goto out_error;
-		} 
-		printf( "Using screen mode %dx%d@%d\n",conn->modes[fc].hdisplay, conn->modes[fc].vdisplay , conn->modes[fc].vrefresh );
-	}
+        int fc = 0;
+        if (mode_width > 0 && mode_height > 0 && mode_vrefresh > 0) {
+                fc = -1;
+                int upscale_candidate = -1;
+                int same_refresh_candidate = -1;
+                int max_candidate = 0;
+                uint64_t requested_area = (uint64_t)mode_width * (uint64_t)mode_height;
+                uint64_t best_upscale_overhead = UINT64_MAX;
+                uint64_t best_same_refresh_area = 0;
+                uint64_t best_max_area = 0;
+                printf("Available modes:\n");
+                for (int i = 0; i < conn->count_modes; i++) {
+                        const drmModeModeInfo *candidate = &conn->modes[i];
+                        uint64_t area = (uint64_t)candidate->hdisplay * (uint64_t)candidate->vdisplay;
+                        printf("%d : %dx%d@%d\n", i, candidate->hdisplay, candidate->vdisplay, candidate->vrefresh);
+                        if (candidate->hdisplay == mode_width &&
+                            candidate->vdisplay == mode_height &&
+                            candidate->vrefresh == mode_vrefresh) {
+                                fc = i;
+                        }
+                        if (area > best_max_area) {
+                                best_max_area = area;
+                                max_candidate = i;
+                        }
+                        if (candidate->vrefresh != mode_vrefresh)
+                                continue;
+                        if (area >= requested_area) {
+                                uint64_t overhead = area - requested_area;
+                                if (overhead < best_upscale_overhead ||
+                                    (overhead == best_upscale_overhead && upscale_candidate >= 0 &&
+                                     area < (uint64_t)conn->modes[upscale_candidate].hdisplay *
+                                             (uint64_t)conn->modes[upscale_candidate].vdisplay)) {
+                                        best_upscale_overhead = overhead;
+                                        upscale_candidate = i;
+                                } else if (overhead == best_upscale_overhead && upscale_candidate < 0) {
+                                        best_upscale_overhead = overhead;
+                                        upscale_candidate = i;
+                                }
+                        }
+                        if (area > best_same_refresh_area) {
+                                best_same_refresh_area = area;
+                                same_refresh_candidate = i;
+                        }
+                }
+                if (fc < 0) {
+                        if (upscale_candidate >= 0) {
+                                fc = upscale_candidate;
+                                fprintf(stderr,
+                                        "couldn't find a matching mode for %dx%d@%d, using %dx%d@%d for upscaling\n",
+                                        mode_width, mode_height, mode_vrefresh,
+                                        conn->modes[fc].hdisplay,
+                                        conn->modes[fc].vdisplay,
+                                        conn->modes[fc].vrefresh);
+                        } else if (same_refresh_candidate >= 0) {
+                                fc = same_refresh_candidate;
+                                fprintf(stderr,
+                                        "couldn't find a matching mode for %dx%d@%d, using %dx%d@%d with matching refresh\n",
+                                        mode_width, mode_height, mode_vrefresh,
+                                        conn->modes[fc].hdisplay,
+                                        conn->modes[fc].vdisplay,
+                                        conn->modes[fc].vrefresh);
+                        } else {
+                                fc = max_candidate;
+                                fprintf(stderr,
+                                        "couldn't find a matching mode for %dx%d@%d, using %dx%d@%d\n",
+                                        mode_width, mode_height, mode_vrefresh,
+                                        conn->modes[fc].hdisplay,
+                                        conn->modes[fc].vdisplay,
+                                        conn->modes[fc].vrefresh);
+                        }
+                }
+                printf("Using screen mode %dx%d@%d\n",
+                       conn->modes[fc].hdisplay,
+                       conn->modes[fc].vdisplay,
+                       conn->modes[fc].vrefresh);
+        }
 	memcpy(&out->mode, &conn->modes[fc], sizeof(out->mode));
 	if (drmModeCreatePropertyBlob(fd, &out->mode, sizeof(out->mode), &out->mode_blob_id) != 0) {
 		fprintf(stderr, "couldn't create a blob property\n");


### PR DESCRIPTION
## Summary
- decouple Cedar stream and display sizing so V4L2 keeps the encoded resolution while DRM can choose high-resolution modes
- perform an initial atomic modeset with the decoded frame before swapping buffers to enable hardware scaling on Allwinner
- add a smarter DRM mode selection fallback that picks suitable higher resolution modes when an exact match is unavailable

## Testing
- ./build_debug_cmake.sh

------
https://chatgpt.com/codex/tasks/task_e_68ffbc9b270c832fa6860c75fc35e958