### PR TITLE
Use GStreamer stdin pipeline for debug sample playback

### DIFF
--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -498,7 +498,7 @@ int main(int argc, char **argv) {
                 std::string("gst-launch-1.0 -q filesrc location=") + debug_sample_path +
                 " ! qtdemux name=demux demux.video_0 ! h264parse config-interval=1 ! "
                 "video/x-h264,stream-format=byte-stream,alignment=au ! queue ! fdsink fd=1 sync=false | "
-                "fpvue --screen-mode 1280x720@60 --cedar";
+                "fpvue --screen-mode 1280x720@60 --rmode 5";
 
             execlp("sh", "sh", "-c", pipeline_command.c_str(), (char *)NULL);
             perror("execlp sample video pipeline");


### PR DESCRIPTION
## Summary
- pipe the debug sample video into fpvue via stdin when --debug is enabled so it avoids the Cedar/OpenMAX path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffc9b55a70832fafdebc7386d582ed