### PR TITLE
Fix blocking atomic plane commits

### DIFF
--- a/drm.c
+++ b/drm.c
@@ -755,9 +755,8 @@ extra_modeset_set_fb(int fd, struct modeset_output *out, struct drm_object *plan
     drmModeAtomicReq *req=drmModeAtomicAlloc();
     if (set_drm_object_property(req, plane, "FB_ID", fb_id) < 0)
         return;
-    int ret, flags;
-    flags = DRM_MODE_ATOMIC_ALLOW_MODESET |  DRM_MODE_ATOMIC_NONBLOCK;
-    ret = drmModeAtomicCommit(fd, req, flags, NULL);
+    int ret;
+    ret = drmModeAtomicCommit(fd, req, 0, NULL);
     if (ret < 0)
         fprintf(stderr, "modeset atomic commit failed for plane %d: %m\n", plane->id);
     drmModeAtomicFree(req);

--- a/main.cpp
+++ b/main.cpp
@@ -589,7 +589,11 @@ void *__DISPLAY_THREAD__(void *param)
             ret = set_drm_object_property(output_list->video_request, &output_list->video_plane, "FB_ID", fb_id);
             assert(ret>0);
 
-            drmModeAtomicCommit(drm_fd, output_list->video_request, DRM_MODE_ATOMIC_NONBLOCK |  DRM_MODE_ATOMIC_ALLOW_MODESET, NULL);
+            int commit_flags = 0;
+            ret = drmModeAtomicCommit(drm_fd, output_list->video_request, commit_flags, NULL);
+            if (ret < 0) {
+                fprintf(stderr, "drmModeAtomicCommit failed for plane %u: %m\n", output_list->video_plane.id);
+            }
         }else if(develop_rendering_mode==1){
             static bool logged_once=false;
             if(!logged_once){


### PR DESCRIPTION
## Summary
- remove non-blocking atomic plane commits that caused repeated EBUSY errors when updating the video plane
- add error handling for blocking atomic commits so failures are surfaced in the log

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ffd8187924832fb86c049be38f5bd0