### PR TITLE
Fix debug pipeline negotiation for omx decoder

### DIFF
--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -496,7 +496,8 @@ int main(int argc, char **argv) {
 
             std::string pipeline_command =
                 std::string("gst-launch-1.0 -q filesrc location=") + debug_sample_path +
-                " ! qtdemux name=demux demux.video_0 ! h264parse config-interval=1 ! queue ! omxh264dec ! "
+                " ! qtdemux name=demux demux.video_0 ! h264parse config-interval=1 "
+                "! video/x-h264,stream-format=byte-stream,alignment=au ! queue ! omxh264dec ! "
                 "videoconvert ! video/x-raw,format=NV12,width=1280,height=720 ! queue ! fdsink fd=1 sync=false | "
                 "fpvue --screen-mode 1280x720@60 --stdin-nv12";
 


### PR DESCRIPTION
## Summary
- ensure the debug gst-launch pipeline advertises byte-stream H.264 output to the hardware decoder
- keep the rest of the debug command unchanged while allowing omxh264dec to negotiate caps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffdf83679c832f85d8d0bff8d29939