### PR TITLE
Add NV21 support for raw input and Allwinner OMX

### DIFF
--- a/allwinnerv4l2display.cpp
+++ b/allwinnerv4l2display.cpp
@@ -175,7 +175,7 @@ bool AllwinnerV4L2Display::setup_drm() {
                       m_display_width,
                       m_display_height,
                       m_display_vrefresh,
-                      DRM_FORMAT_NV12,
+                      DRM_FORMAT_NV21,
                       MODESET_PLANE_TYPE_PRIMARY) < 0) {
     std::cerr << "modeset_prepare failed" << std::endl;
     return false;
@@ -240,7 +240,7 @@ bool AllwinnerV4L2Display::ensure_display_buffers(uint32_t width, uint32_t heigh
   recycle_display_buffers();
 
   debug_log("cedar", "Allocating ", kDisplayBufferCount,
-            " DRM NV12 buffers for ", width, "x", height);
+            " DRM NV21 buffers for ", width, "x", height);
 
   m_drm_buffers.resize(kDisplayBufferCount);
   uint32_t stride = width;
@@ -272,7 +272,7 @@ bool AllwinnerV4L2Display::ensure_display_buffers(uint32_t width, uint32_t heigh
     if (drmModeAddFB2(m_drm_fd,
                       width,
                       height,
-                      DRM_FORMAT_NV12,
+                      DRM_FORMAT_NV21,
                       handles,
                       pitches,
                       offsets,
@@ -575,7 +575,7 @@ void AllwinnerV4L2Display::teardown_omx() {
   m_decoder_state = OMX_StateLoaded;
 }
 
-static void copy_planar_to_nv12(uint8_t* dst,
+static void copy_planar_to_nv21(uint8_t* dst,
                                 uint32_t dst_stride,
                                 uint32_t dst_uv_stride,
                                 const uint8_t* src,
@@ -595,8 +595,8 @@ static void copy_planar_to_nv12(uint8_t* dst,
     const uint8_t* u_row = src_u + row * (width / 2);
     const uint8_t* v_row = src_v + row * (width / 2);
     for (uint32_t col = 0; col < width / 2; ++col) {
-      dst_row[2 * col] = u_row[col];
-      dst_row[2 * col + 1] = v_row[col];
+      dst_row[2 * col] = v_row[col];
+      dst_row[2 * col + 1] = u_row[col];
     }
   }
 }
@@ -725,7 +725,7 @@ void AllwinnerV4L2Display::decode_loop() {
     } else if (output_buffer->nFilledLen > 0) {
       auto& drm_buf = m_drm_buffers[m_drm_buffer_index];
       uint8_t* dst = static_cast<uint8_t*>(drm_buf.map);
-      copy_planar_to_nv12(dst,
+      copy_planar_to_nv21(dst,
                           m_display_stride,
                           m_display_stride,
                           output_buffer->pBuffer + output_buffer->nOffset,

--- a/display_host_main.cpp
+++ b/display_host_main.cpp
@@ -442,13 +442,13 @@ static std::string build_sample_video_pipeline_command(const char *debug_sample_
                      << "    gst-launch-1.0 -q filesrc location=" << debug_sample_path
                      << " ! qtdemux name=demux demux.video_0 ! h264parse config-interval=1"
                      << " ! video/x-h264,stream-format=byte-stream,alignment=au ! queue ! \"$decoder\""
-                     << " ! videoconvert ! video/x-raw,format=NV12,width=1280,height=720 ! queue ! fdsink fd=1 sync=false;\n"
+                     << " ! videoconvert ! video/x-raw,format=NV21,width=1280,height=720 ! queue ! fdsink fd=1 sync=false;\n"
                      << "}\n"
                      << "(run_decoder omxh264dec || run_decoder mppvideodec || run_decoder avdec_h264)";
 
     std::string pipeline_command = "(";
     pipeline_command += pipeline_builder.str();
-    pipeline_command += ") | fpvue --screen-mode 1280x720@60 --stdin-nv12";
+    pipeline_command += ") | fpvue --screen-mode 1280x720@60 --stdin-nv21";
     return pipeline_command;
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <cctype>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -1008,6 +1009,7 @@ void printHelp() {
     "    --cedar            - force Cedar hardware decode fallback path\n"
     "\n"
     "    --stdin-nv12        - display raw NV12 frames from stdin\n"
+    "    --stdin-nv21        - display raw NV21 frames from stdin\n"
     "\n"
     "    --color-cycle      - display green, red and blue test screen\n"
     "\n"
@@ -1082,7 +1084,36 @@ bool x20_auto=false;
 bool aw_display=false;
 bool color_cycle=false;
 bool force_cedar=false;
-bool stdin_nv12_mode=false;
+
+enum class StdinRawFormat {
+    None,
+    NV12,
+    NV21,
+};
+
+StdinRawFormat stdin_raw_format = StdinRawFormat::None;
+
+static const char *stdin_format_flag(StdinRawFormat fmt) {
+    switch (fmt) {
+    case StdinRawFormat::NV12:
+        return "--stdin-nv12";
+    case StdinRawFormat::NV21:
+        return "--stdin-nv21";
+    default:
+        return "";
+    }
+}
+
+static const char *stdin_format_name(StdinRawFormat fmt) {
+    switch (fmt) {
+    case StdinRawFormat::NV12:
+        return "NV12";
+    case StdinRawFormat::NV21:
+        return "NV21";
+    default:
+        return "";
+    }
+}
 
 static bool read_env_uint32(const char *name, uint32_t &value) {
     const char *env = getenv(name);
@@ -1154,33 +1185,56 @@ static bool select_plane_for_output(int fd,
 // main
 
 
-int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
+static std::string to_lowercase(const std::string &value) {
+    std::string lower = value;
+    for (char &ch : lower) {
+        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    }
+    return lower;
+}
+
+static int run_stdin_raw(const std::vector<ScreenMode> &modes,
+                         const char *format_name,
+                         const char *env_prefix,
+                         uint32_t drm_format) {
     if (modes.empty()) {
-        fprintf(stderr, "stdin NV12 mode requires at least one screen mode candidate.\n");
+        fprintf(stderr,
+                "stdin %s mode requires at least one screen mode candidate.\n",
+                format_name);
         return 1;
     }
 
+    const std::string env_prefix_str(env_prefix);
+    const std::string option_flag = std::string("--stdin-") + to_lowercase(format_name);
+
     enum modeset_plane_type plane_type = MODESET_PLANE_TYPE_PRIMARY;
-    const char *plane_type_env = getenv("FPVUE_STDIN_NV12_PLANE_TYPE");
+    const std::string plane_type_env_name = env_prefix_str + "_PLANE_TYPE";
+    const char *plane_type_env = getenv(plane_type_env_name.c_str());
     if (plane_type_env && strcmp(plane_type_env, "overlay") == 0) {
         plane_type = MODESET_PLANE_TYPE_OVERLAY;
     }
 
     uint32_t requested_plane_id = 0;
-    bool have_plane_request = read_env_uint32("FPVUE_STDIN_NV12_PLANE_ID", requested_plane_id);
+    const std::string plane_id_env_name = env_prefix_str + "_PLANE_ID";
+    bool have_plane_request = read_env_uint32(plane_id_env_name.c_str(), requested_plane_id);
 
     uint32_t dst_width_override = 0;
     uint32_t dst_height_override = 0;
-    bool have_dst_width = read_env_uint32("FPVUE_STDIN_NV12_CRTC_WIDTH", dst_width_override);
-    bool have_dst_height = read_env_uint32("FPVUE_STDIN_NV12_CRTC_HEIGHT", dst_height_override);
+    const std::string crtc_width_env_name = env_prefix_str + "_CRTC_WIDTH";
+    const std::string crtc_height_env_name = env_prefix_str + "_CRTC_HEIGHT";
+    bool have_dst_width = read_env_uint32(crtc_width_env_name.c_str(), dst_width_override);
+    bool have_dst_height = read_env_uint32(crtc_height_env_name.c_str(), dst_height_override);
 
     int dst_x_override = 0;
     int dst_y_override = 0;
-    bool have_dst_x = read_env_int("FPVUE_STDIN_NV12_CRTC_X", dst_x_override);
-    bool have_dst_y = read_env_int("FPVUE_STDIN_NV12_CRTC_Y", dst_y_override);
+    const std::string crtc_x_env_name = env_prefix_str + "_CRTC_X";
+    const std::string crtc_y_env_name = env_prefix_str + "_CRTC_Y";
+    bool have_dst_x = read_env_int(crtc_x_env_name.c_str(), dst_x_override);
+    bool have_dst_y = read_env_int(crtc_y_env_name.c_str(), dst_y_override);
 
     int plane_zpos = 0;
-    read_env_int("FPVUE_STDIN_NV12_ZPOS", plane_zpos);
+    const std::string zpos_env_name = env_prefix_str + "_ZPOS";
+    read_env_int(zpos_env_name.c_str(), plane_zpos);
 
     const char *fd_socket = getenv("FPVUE_DRM_FD_SOCKET");
     int drm_fd = -1;
@@ -1194,14 +1248,16 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
 
     if (drm_fd < 0) {
         if (modeset_open(&drm_fd, "/dev/dri/card0") < 0) {
-            fprintf(stderr, "Unable to open DRM node for stdin NV12 mode.\n");
+            fprintf(stderr,
+                    "Unable to open DRM node for stdin %s mode.\n",
+                    format_name);
             return 1;
         }
     }
 
     struct modeset_output *out = nullptr;
 
-    struct RawNv12Buffer {
+    struct RawYuvBuffer {
         uint32_t fb_id{0};
         uint32_t handle{0};
         void *map{nullptr};
@@ -1209,8 +1265,8 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
         uint32_t pitch{0};
     };
 
-    std::vector<RawNv12Buffer> buffers;
-    auto destroy_buffer = [&](RawNv12Buffer &buf) {
+    std::vector<RawYuvBuffer> buffers;
+    auto destroy_buffer = [&](RawYuvBuffer &buf) {
         if (buf.map && buf.map != MAP_FAILED) {
             munmap(buf.map, buf.size);
             buf.map = nullptr;
@@ -1240,41 +1296,40 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
 
     ScreenMode selected_mode = modes.front();
     if (modes.size() > 1) {
-        printf("Trying %zu screen mode candidates for stdin NV12 input.\n", modes.size());
+        printf("Trying %zu screen mode candidates for stdin %s input.\n",
+               modes.size(),
+               format_name);
     }
+
     for (size_t idx = 0; idx < modes.size(); ++idx) {
-        const ScreenMode &candidate = modes[idx];
+        ScreenMode candidate = modes[idx];
         struct modeset_output *candidate_out = static_cast<struct modeset_output *>(calloc(1, sizeof(*candidate_out)));
         if (!candidate_out) {
-            perror("calloc modeset_output");
+            fprintf(stderr,
+                    "Failed to allocate modeset output structure for stdin %s mode.\n",
+                    format_name);
             exit_code = 1;
-            goto finish;
+            break;
         }
+
         if (modeset_prepare(drm_fd,
                             candidate_out,
                             candidate.width,
                             candidate.height,
                             candidate.vrefresh,
-                            DRM_FORMAT_NV12,
-                            plane_type) == 0) {
-            bool usable_candidate = true;
-            if (have_plane_request && requested_plane_id != 0 &&
-                !select_plane_for_output(drm_fd, candidate_out, requested_plane_id, DRM_FORMAT_NV12)) {
-                fprintf(stderr,
-                        "Failed to select requested plane %u for stdin NV12 mode; trying next candidate.\n",
-                        requested_plane_id);
-                usable_candidate = false;
-            }
-            if (usable_candidate) {
-                out = candidate_out;
-                prepared = true;
-                selected_mode = candidate;
-                break;
-            }
+                            drm_format,
+                            plane_type) == 0 &&
+            (!have_plane_request ||
+             select_plane_for_output(drm_fd, candidate_out, requested_plane_id, drm_format))) {
+            out = candidate_out;
+            prepared = true;
+            selected_mode = candidate;
+            break;
         }
 
         fprintf(stderr,
-                "Failed to prepare DRM output for stdin NV12 mode using %ux%u@%u%s\n",
+                "Failed to prepare DRM output for stdin %s mode using %ux%u@%u%s\n",
+                format_name,
                 candidate.width,
                 candidate.height,
                 candidate.vrefresh,
@@ -1287,7 +1342,9 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
     }
 
     if (!prepared) {
-        fprintf(stderr, "Unable to configure any of the requested screen modes for stdin NV12 input.\n");
+        fprintf(stderr,
+                "Unable to configure any of the requested screen modes for stdin %s input.\n",
+                format_name);
         exit_code = 1;
         goto finish;
     }
@@ -1325,7 +1382,8 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
     frame_height = out->video_frm_height ? out->video_frm_height : selected_mode.height;
     if (frame_width == 0 || frame_height == 0) {
         fprintf(stderr,
-                "Invalid frame dimensions for stdin NV12 mode (%ux%u).\n",
+                "Invalid frame dimensions for stdin %s mode (%ux%u).\n",
+                format_name,
                 frame_width,
                 frame_height);
         exit_code = 1;
@@ -1333,9 +1391,13 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
     }
 
     frame_size = static_cast<size_t>(frame_width) * frame_height * 3 / 2;
-    printf("Rendering raw NV12 stream %ux%u@%u from stdin.\n", frame_width, frame_height, selected_mode.vrefresh);
+    printf("Rendering raw %s stream %ux%u@%u from stdin.\n",
+           format_name,
+           frame_width,
+           frame_height,
+           selected_mode.vrefresh);
 
-    buffers.assign(3, RawNv12Buffer{});
+    buffers.assign(3, RawYuvBuffer{});
     for (auto &buf : buffers) {
         struct drm_mode_create_dumb create{};
         create.width = frame_width;
@@ -1357,7 +1419,7 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
             drmModeAddFB2(drm_fd,
                           frame_width,
                           frame_height,
-                          DRM_FORMAT_NV12,
+                          drm_format,
                           handles,
                           pitches,
                           offsets,
@@ -1398,13 +1460,15 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
                                  frame_width,
                                  frame_height,
                                  plane_zpos) != 0) {
-        fprintf(stderr, "Failed to submit initial frame for stdin NV12 mode.\n");
+        fprintf(stderr,
+                "Failed to submit initial frame for stdin %s mode.\n",
+                format_name);
         exit_code = 1;
         goto finish;
     }
 
     while (!signal_flag && !eof) {
-        RawNv12Buffer &buf = buffers[buffer_index];
+        RawYuvBuffer &buf = buffers[buffer_index];
         uint8_t *dst = static_cast<uint8_t *>(buf.map);
         size_t remaining = frame_size;
         size_t offset = 0;
@@ -1430,7 +1494,10 @@ int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
         }
         if (!encoded_input_warning_emitted && looks_like_annexb_stream(dst, frame_size)) {
             fprintf(stderr,
-                    "Input appears to contain Annex B encoded video (e.g. H.264/H.265). --stdin-nv12 expects raw NV12 frames. Ensure your pipeline decodes the stream before piping it into fpvue (for example, add '... ! decodebin ! videoconvert ! video/x-raw,format=NV12 ! fdsink fd=1').\n");
+                    "Input appears to contain Annex B encoded video (e.g. H.264/H.265). %s expects raw %s frames. Ensure your pipeline decodes the stream before piping it into fpvue (for example, add '... ! decodebin ! videoconvert ! video/x-raw,format=%s ! fdsink fd=1').\n",
+                    option_flag.c_str(),
+                    format_name,
+                    format_name);
             encoded_input_warning_emitted = true;
         }
         extra_modeset_set_fb(drm_fd, out, &out->video_plane, buf.fb_id);
@@ -1467,6 +1534,14 @@ finish:
         close(drm_fd);
     }
     return exit_code;
+}
+
+int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
+    return run_stdin_raw(modes, "NV12", "FPVUE_STDIN_NV12", DRM_FORMAT_NV12);
+}
+
+int run_stdin_nv21(const std::vector<ScreenMode> &modes) {
+    return run_stdin_raw(modes, "NV21", "FPVUE_STDIN_NV21", DRM_FORMAT_NV21);
 }
 
 
@@ -1693,7 +1768,11 @@ int main(int argc, char **argv)
         continue;
     }
     __OnArgument("--stdin-nv12") {
-        stdin_nv12_mode=true;
+        stdin_raw_format = StdinRawFormat::NV12;
+        continue;
+    }
+    __OnArgument("--stdin-nv21") {
+        stdin_raw_format = StdinRawFormat::NV21;
         continue;
     }
     __OnArgument("--color-cycle") {
@@ -1741,7 +1820,7 @@ int main(int argc, char **argv)
 #if HAVE_ROCKCHIP
     // H264 or H265
     MppCodingType mpp_type = MPP_VIDEO_CodingAVC;
-    if (!stdin_nv12_mode) {
+    if (stdin_raw_format == StdinRawFormat::None) {
         if(decode_h265){
             printf("Decoding h265\n");
             mpp_type = MPP_VIDEO_CodingHEVC;
@@ -1753,16 +1832,26 @@ int main(int argc, char **argv)
     signal(SIGINT, sig_handler);
     signal(SIGPIPE, sig_handler);
     printf("Rendering mode %d\n",develop_rendering_mode);
-    if(stdin_nv12_mode){
+    if(stdin_raw_format != StdinRawFormat::None){
+        const char *flag = stdin_format_flag(stdin_raw_format);
+        const char *format_name = stdin_format_name(stdin_raw_format);
         if (udp_port != -1) {
-            fprintf(stderr, "--stdin-nv12 ignores UDP input; reading from stdin.\n");
+            fprintf(stderr, "%s ignores UDP input; reading from stdin.\n", flag);
             udp_port = -1;
         }
         if (aw_display) {
-            fprintf(stderr, "--stdin-nv12 overrides --aw-display Cedar path.\n");
+            fprintf(stderr, "%s overrides --aw-display Cedar path.\n", flag);
             aw_display = false;
         }
-        return run_stdin_nv12(screen_modes);
+        switch (stdin_raw_format) {
+        case StdinRawFormat::NV12:
+            return run_stdin_nv12(screen_modes);
+        case StdinRawFormat::NV21:
+            return run_stdin_nv21(screen_modes);
+        default:
+            fprintf(stderr, "Unsupported stdin raw format '%s'.\n", format_name);
+            return 1;
+        }
     }
     if(color_cycle){
         return run_color_cycle(mode_width,mode_height,mode_vrefresh);


### PR DESCRIPTION
## Summary
- configure the Allwinner OMX display path to allocate NV21 buffers and convert planar output to VU interleaved format
- generalize stdin raw rendering to handle NV12 or NV21 with a shared helper and new `--stdin-nv21` option
- switch the display host debug pipeline to emit NV21 frames for Cedar testing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fffe8302a8832f905b5f78cb4a73a9