### PR TITLE
Fix build regressions for stdin NV modes

### DIFF
--- a/copy_util.h
+++ b/copy_util.h
@@ -131,9 +131,11 @@ void memcpy_threaded(void* dest,void* src, int len,int n_threads){
     struct memcpy_args_t memcpyArgs[100];
     int consumed=0;
     int chunck=len/(n_threads);
+    char *src_bytes = static_cast<char *>(src);
+    char *dst_bytes = static_cast<char *>(dest);
     for(int i=0;i<n_threads;i++){
-        memcpyArgs[i].src=src+consumed;
-        memcpyArgs[i].dst=dest+consumed;
+        memcpyArgs[i].src = src_bytes + consumed;
+        memcpyArgs[i].dst = dst_bytes + consumed;
         int this_thread_len;
         if(i==n_threads-1){
             // might not be even

--- a/drm.h
+++ b/drm.h
@@ -5,7 +5,9 @@
 #ifndef DRM_H
 #define DRM_H
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>

--- a/drm_fd_preload.cpp
+++ b/drm_fd_preload.cpp
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include "display_host.h"
 
 #include <dlfcn.h>

--- a/main.cpp
+++ b/main.cpp
@@ -1273,7 +1273,7 @@ int run_stdin_nv_mode(const std::vector<ScreenMode> &modes, const NvStdinConfig 
         if (!candidate_out) {
             fprintf(stderr,
                     "Failed to allocate modeset output structure for stdin %s mode.\n",
-                    format_name);
+                    config.mode_name);
             exit_code = 1;
             break;
         }
@@ -1504,11 +1504,11 @@ finish:
 }
 
 int run_stdin_nv12(const std::vector<ScreenMode> &modes) {
-    return run_stdin_raw(modes, "NV12", "FPVUE_STDIN_NV12", DRM_FORMAT_NV12);
+    return run_stdin_nv_mode(modes, kNv12Config);
 }
 
 int run_stdin_nv21(const std::vector<ScreenMode> &modes) {
-    return run_stdin_raw(modes, "NV21", "FPVUE_STDIN_NV21", DRM_FORMAT_NV21);
+    return run_stdin_nv_mode(modes, kNv21Config);
 }
 
 


### PR DESCRIPTION
## Summary
- guard the `_GNU_SOURCE` definition to avoid redundant macro warnings when compiling
- fix void-pointer arithmetic in the threaded memcpy helper
- route NV12/NV21 stdin helpers through the shared NV mode implementation

## Testing
- ./build_debug_cmake.sh

------
https://chatgpt.com/codex/tasks/task_e_6900077aa0ac832fbe56340aeeb8e79e